### PR TITLE
Added configmap permissions for OCM

### DIFF
--- a/deploy/uhc_cluster_role.yaml
+++ b/deploy/uhc_cluster_role.yaml
@@ -13,3 +13,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  attributeRestrictions: null
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update


### PR DESCRIPTION
This PR adds configmap permissions for the UCH/OCM Role. 

These permissions are required since OCM uses configmaps for their leader elections. 