### PR TITLE
Migrated to new secret name

### DIFF
--- a/pkg/controller/projectreference/projectreference_adapter.go
+++ b/pkg/controller/projectreference/projectreference_adapter.go
@@ -320,7 +320,7 @@ func (r *ReferenceAdapter) createCredentials() error {
 	r.logger.Info(fmt.Sprintf("Creating Secret %s in namespace %s", r.projectClaim.Spec.GCPCredentialSecret.Name, r.projectClaim.Spec.GCPCredentialSecret.Namespace))
 	createErr := r.kubeClient.Create(context.TODO(), secret)
 	if createErr != nil {
-		r.logger.Error(createErr, "could not create service account cred secret ", "Service Account Secret Name", gcpSecretName)
+		r.logger.Error(createErr, "could not create service account cred secret ", "Service Account Secret Name", r.projectClaim.Spec.GCPCredentialSecret.Name)
 		return createErr
 	}
 

--- a/pkg/controller/projectreference/projectreference_controller.go
+++ b/pkg/controller/projectreference/projectreference_controller.go
@@ -27,8 +27,7 @@ const (
 	operatorNamespace = "gcp-project-operator"
 
 	// secret information
-	gcpSecretName    = "gcp"
-	orgGcpSecretName = "gcp-project-operator"
+	orgGcpSecretName = "gcp-project-operator-credentials"
 
 	// Configmap related configs
 	orgGcpConfigMap = "gcp-project-operator"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -15,8 +15,7 @@ import (
 
 const (
 	// secret information
-	gcpSecretName    = "gcp"
-	orgGcpSecretName = "gcp-project-operator"
+	gcpSecretName = "gcp"
 )
 
 // SecretExists returns a boolean to the caller based on the secretName and namespace args.

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -142,7 +142,7 @@ func TestNewGCPSecretCR(t *testing.T) {
 	}
 }
 
-func TestGetOrgGCPCreds(t *testing.T) {
+func TestGetGCPCredentialsFromSecret(t *testing.T) {
 	tests := []struct {
 		name            string
 		localObjects    []runtime.Object
@@ -184,7 +184,7 @@ func TestGetOrgGCPCreds(t *testing.T) {
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      orgGcpSecretName,
+						Name:      "badName",
 						Namespace: "testNamespace",
 					},
 				}


### PR DESCRIPTION
This PR removes references to the old secret name and updates the code base to get the new secret name "gcp-project-operator-credentials"