### PR TITLE
ClusterDeploymentController can be turned off

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -19,8 +19,9 @@ const (
 
 // OperatorConfigMap store data for the specified configmap
 type OperatorConfigMap struct {
-	BillingAccount string `mapstructure:"billingAccount"`
-	ParentFolderID string `mapstructure:"parentFolderID"`
+	BillingAccount              string `mapstructure:"billingAccount"`
+	ParentFolderID              string `mapstructure:"parentFolderID"`
+	ClusterDeploymentController string `mapstructure:"clusterDeploymentController" optional:"true"`
 }
 
 // ValidateOperatorConfigMap checks if OperatorConfigMap filled properly
@@ -29,7 +30,8 @@ func ValidateOperatorConfigMap(configmap OperatorConfigMap) error {
 	typeOfS := v.Type()
 
 	for i := 0; i < v.NumField(); i++ {
-		if v.Field(i).Interface() == "" {
+		optional, _ := typeOfS.Field(i).Tag.Lookup("optional")
+		if v.Field(i).Interface() == "" && optional != "true" {
 			return fmt.Errorf("missing configmap key: %s", typeOfS.Field(i).Name)
 		}
 	}

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -25,17 +25,23 @@ func TestValidateOperatorConfigMap(t *testing.T) {
 	if err = ValidateOperatorConfigMap(sut); err != nil {
 		t.Errorf("no err expected since OperatorConfigMap filled properly")
 	}
+
+	sut.ClusterDeploymentController = "disabled"
+	if err = ValidateOperatorConfigMap(sut); err != nil {
+		t.Errorf("no err expected since OperatorConfigMap filled properly")
+	}
 }
 
 func TestGetOperatorConfigMap(t *testing.T) {
 	tests := []struct {
-		name                   string
-		localObjects           []runtime.Object
-		expectedParentFolderID string
-		expectedBillingAccount string
-		expectedErr            error
-		validateResult         func(*testing.T, string, string)
-		validateErr            func(*testing.T, error, error)
+		name                                string
+		localObjects                        []runtime.Object
+		expectedParentFolderID              string
+		expectedBillingAccount              string
+		expectedClusterDeploymentController string
+		expectedErr                         error
+		validateResult                      func(*testing.T, string, string)
+		validateErr                         func(*testing.T, error, error)
 	}{
 		{
 			name: "Correct parentFolderID and billingAccount exist in configmap",
@@ -81,6 +87,18 @@ func TestGetOperatorConfigMap(t *testing.T) {
 				assert.Equal(t, expected, result)
 			},
 		},
+		{
+			name: "Optional parameter clusterDeploymentController set",
+			localObjects: []runtime.Object{
+				builders.NewTestConfigMapBuilder("gcp-project-operator", "gcp-project-operator", "billing123", "1234567").WithClusterDeploymentControllerDisabled().GetConfigMap(),
+			},
+			expectedParentFolderID:              "1234567",
+			expectedBillingAccount:              "billing123",
+			expectedClusterDeploymentController: "disabled",
+			validateResult: func(t *testing.T, expected, result string) {
+				assert.Equal(t, expected, result)
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -98,6 +116,7 @@ func TestGetOperatorConfigMap(t *testing.T) {
 			if test.validateResult != nil {
 				test.validateResult(t, test.expectedParentFolderID, operatorConfigMap.ParentFolderID)
 				test.validateResult(t, test.expectedBillingAccount, operatorConfigMap.BillingAccount)
+				test.validateResult(t, test.expectedClusterDeploymentController, operatorConfigMap.ClusterDeploymentController)
 			}
 
 			if test.validateErr != nil {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -142,9 +142,19 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling ClusterDeployment")
 
+	config, err := configmap.GetOperatorConfigMap(r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if config.ClusterDeploymentController == "disabled" {
+		reqLogger.Info("ClusterDeployment controller disabled. Not reconciling.")
+		return reconcile.Result{}, nil
+	}
+
 	// Fetch the ClusterDeployment instance
 	cd := &hivev1alpha1.ClusterDeployment{}
-	err := r.client.Get(context.Background(), request.NamespacedName, cd)
+	err = r.client.Get(context.Background(), request.NamespacedName, cd)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/pkg/controller/clusterdeployment/clusterdeploymet_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeploymet_controller_test.go
@@ -34,12 +34,16 @@ func TestReconcile(t *testing.T) {
 			name:         "cluster deployment not found",
 			expectedErr:  nil,
 			setupGCPMock: func(r *mockGCP.MockClientMockRecorder) { gomock.Any() },
+			localObjects: []runtime.Object{
+				builders.NewTestConfigMapBuilder(orgGcpSecretName, operatorNamespace, "foo", "111111").GetConfigMap(),
+			},
 		},
 		{
 			name:        "CD check fail ErrMissingRegion",
 			expectedErr: fmt.Errorf("MissingRegion"),
 			localObjects: []runtime.Object{
 				builders.NewTestClusterDeploymentBuilder().WithOutRegion().GetClusterDeployment(),
+				builders.NewTestConfigMapBuilder(orgGcpSecretName, operatorNamespace, "foo", "111111").GetConfigMap(),
 			},
 			setupGCPMock: func(r *mockGCP.MockClientMockRecorder) { gomock.Any() },
 		},
@@ -48,6 +52,7 @@ func TestReconcile(t *testing.T) {
 			expectedErr: nil,
 			localObjects: []runtime.Object{
 				builders.NewTestClusterDeploymentBuilder().Installed().GetClusterDeployment(),
+				builders.NewTestConfigMapBuilder(orgGcpSecretName, operatorNamespace, "foo", "111111").GetConfigMap(),
 			},
 			setupGCPMock: func(r *mockGCP.MockClientMockRecorder) { gomock.Any() },
 		},

--- a/pkg/util/mocks/structs/core.go
+++ b/pkg/util/mocks/structs/core.go
@@ -68,3 +68,8 @@ func (c *testConfigMapBuilder) WithoutKey(key string) *testConfigMapBuilder {
 	delete(c.cfg.Data, key)
 	return c
 }
+
+func (c *testConfigMapBuilder) WithClusterDeploymentControllerDisabled() *testConfigMapBuilder {
+	c.cfg.Data["clusterDeploymentController"] = "disabled"
+	return c
+}


### PR DESCRIPTION
* ClusterDeploymentController can be turned off using a setting in the configmap
* ConfigMap can contain optional settings