### PR TITLE
GCP Project cleanup

### DIFF
--- a/pkg/controller/projectreference/projectreference_controller_test.go
+++ b/pkg/controller/projectreference/projectreference_controller_test.go
@@ -30,6 +30,8 @@ const (
 	testNamespace            = "namespace"
 )
 
+const ProjectReferenceFinalizer string = "finalizer.gcp.managed.openshift.io"
+
 var _ = Describe("ProjectReference controller reconcilation", func() {
 	var (
 		projectReference     *api.ProjectReference
@@ -340,8 +342,7 @@ var _ = Describe("ProjectReference controller reconcilation", func() {
 				mockGCPClient.EXPECT().SetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil)
 				mockGCPClient.EXPECT().CreateServiceAccountKey(gomock.Any()).Return(&iam.ServiceAccountKey{PrivateKeyData: "dGVzdAo="}, nil)
 				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
-				mockKubeClient.EXPECT().Status().Return(mockUpdater)
-				mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()).Return(errors.New("Fake update Error"))
+				mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(errors.New("Fake update Error"))
 				_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: projectReferenceName})
 				Expect(err).To(HaveOccurred())
 			})
@@ -360,6 +361,7 @@ var _ = Describe("ProjectReference controller reconcilation", func() {
 				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
 				mockKubeClient.EXPECT().Status().Return(mockUpdater)
 				mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any())
+				mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 				_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: projectReferenceName})
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/pkg/controller/projectreference/projectreference_controller_test.go
+++ b/pkg/controller/projectreference/projectreference_controller_test.go
@@ -15,7 +15,9 @@ import (
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/iam/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	k8serrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -367,6 +369,39 @@ var _ = Describe("ProjectReference controller reconcilation", func() {
 			})
 		})
 
+	})
+	Context("Given there is a ProjectReference deletion request", func() {
+		BeforeEach(func() {
+			deletionTime := metav1.NewTime(time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC))
+			projectReference.SetDeletionTimestamp(&deletionTime)
+			mockKubeClient.EXPECT().Get(gomock.Any(), projectReferenceName, gomock.Any()).SetArg(2, *projectReference).Times(1)
+			mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, v1.Secret{
+				Data: map[string][]byte{"osServiceAccount.json": []byte("fakedata"), "key.json": []byte("fakedata")},
+			}).Times(1)
+			mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		})
+		Context("When cleanup succeeds", func() {
+			It("does not requeue", func() {
+				mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
+				mockGCPClient.EXPECT().DeleteProject(gomock.Any()).Times(1)
+				mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, v1.Secret{}).Times(2)
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil)
+
+				_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: projectReferenceName})
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Context("When cleanup fails", func() {
+			It("Gets requeued after 5 seconds", func() {
+				mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
+				mockGCPClient.EXPECT().DeleteProject(gomock.Any()).Times(1)
+				mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, v1.Secret{}).Times(2)
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(errors.New("Cannot delete the project"))
+				result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: projectReferenceName})
+				Expect(err).To(HaveOccurred())
+				Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+			})
+		})
 	})
 
 })

--- a/pkg/gcpclient/client.go
+++ b/pkg/gcpclient/client.go
@@ -43,6 +43,7 @@ type Client interface {
 	ListProjects() ([]*cloudresourcemanager.Project, error)
 	CreateProject(parentFolder string) (*cloudresourcemanager.Operation, error)
 	DeleteProject(parentFolder string) (*cloudresourcemanager.Empty, error)
+	GetProject(projectID string) (*cloudresourcemanager.Project, error)
 
 	// ServiceManagement
 	EnableAPI(projectID, api string) error
@@ -114,6 +115,15 @@ func (c *gcpClient) ListProjects() ([]*cloudresourcemanager.Project, error) {
 		return []*cloudresourcemanager.Project{}, err
 	}
 	return resp.Projects, nil
+}
+
+// GetProject returns a project
+func (c *gcpClient) GetProject(projectID string) (*cloudresourcemanager.Project, error) {
+	project, err := c.cloudResourceManagerClient.Projects.Get(projectID).Do()
+	if err != nil {
+		return nil, err
+	}
+	return project, nil
 }
 
 // CreateProject creates a project in a given folder.

--- a/pkg/util/mocks/gcpclient/client.go
+++ b/pkg/util/mocks/gcpclient/client.go
@@ -183,6 +183,21 @@ func (mr *MockClientMockRecorder) DeleteProject(parentFolder interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProject", reflect.TypeOf((*MockClient)(nil).DeleteProject), parentFolder)
 }
 
+// GetProject mocks base method
+func (m *MockClient) GetProject(projectID string) (*cloudresourcemanager.Project, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProject", projectID)
+	ret0, _ := ret[0].(*cloudresourcemanager.Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProject indicates an expected call of GetProject
+func (mr *MockClientMockRecorder) GetProject(projectID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockClient)(nil).GetProject), projectID)
+}
+
 // EnableAPI mocks base method
 func (m *MockClient) EnableAPI(projectID, api string) error {
 	m.ctrl.T.Helper()

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,8 +26,8 @@ func SecretExists(kubeClient client.Client, secretName, namespace string) bool {
 	return err == nil
 }
 
-// getSecret returns a secret based on a secretName and namespace.
-func getSecret(kubeClient client.Client, secretName, namespace string) (*corev1.Secret, error) {
+// GetSecret returns a secret based on a secretName and namespace.
+func GetSecret(kubeClient client.Client, secretName, namespace string) (*corev1.Secret, error) {
 	s := &corev1.Secret{}
 
 	err := kubeClient.Get(context.TODO(), kubetypes.NamespacedName{Name: secretName, Namespace: namespace}, s)

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -93,7 +93,7 @@ func TestGetSecret(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			mocks := builders.SetupDefaultMocks(t, test.localObjects)
 
-			result, err := getSecret(mocks.FakeKubeClient, test.secretName, test.secretNamespace)
+			result, err := GetSecret(mocks.FakeKubeClient, test.secretName, test.secretNamespace)
 
 			if test.expectedErr {
 				assert.Error(t, err)


### PR DESCRIPTION
* Adds a finalizer to the ProjectReference CR during its creation
* Checks for DeletionTimestamp request and signals the cleanup
* Checks the lifecycle status of the GCP Project
* Deletes the Project from Google GCP or skip if it's already deleted
* Implements GetProject()
* Checks the exitence of secret and gets it
* Deletes the secret from the cluster or skip if it's already deleted
* Deletes the finalizer if cleanup done properly

Fixes OSD-3064

Tests have been added as well