### PR TITLE
Fix ProjectReference CR yaml

### DIFF
--- a/deploy/crds/gcp_v1alpha1_projectreference_cr.yaml
+++ b/deploy/crds/gcp_v1alpha1_projectreference_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: gcp.managed.openshift.io/v1alpha1
 kind: ProjectReference
 metadata:
-  name: example-projectreference
+  name: example-clusternamespace-example-projectclaim
   namespace: gcp-project-operator
 spec:
   # Add fields here


### PR DESCRIPTION
The name of the ProjectReference CR is not corresponding to the  name generated by the ProjectClaim CR. This PR applies the same logic as gcp-project-operator would have done it:

  name: `<namespace of projectclaim cr>-<name of projectclaim cr>`

See [here](https://github.com/openshift/gcp-project-operator/blob/master/pkg/controller/projectclaim/customresourceadapter.go#L40)