### PR TITLE
Reduce length of ProjectID to 10

### DIFF
--- a/pkg/controller/projectreference/projectreference_adapter.go
+++ b/pkg/controller/projectreference/projectreference_adapter.go
@@ -261,8 +261,8 @@ func GenerateProjectID() (string, error) {
 		return "", err
 	}
 	uuidsum := fmt.Sprintf("%x", hashing.Sum(nil))
-	shortuuid := uuidsum[0:26]
-	return "osd-" + shortuuid, nil
+	shortuuid := uuidsum[0:8]
+	return "o-" + shortuuid, nil
 }
 
 // updateProjectID updates the ProjectReference with a unique ID for the ProjectID


### PR DESCRIPTION
This PR reduces the length of the ProjectID to 10, Due to a bug that causes the hostname of the GCP instance to be set to localhost if the length of the instance FQDN exceeds 64 characters. 


https://issues.redhat.com/browse/OSD-3129
https://bugzilla.redhat.com/show_bug.cgi?id=1809345
