### PR TITLE
Handle deletion before error check

### DIFF
--- a/pkg/controller/projectreference/projectreference_adapter_test.go
+++ b/pkg/controller/projectreference/projectreference_adapter_test.go
@@ -326,23 +326,39 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 		})
 
 		Context("EnsureProjectCleanedUp", func() {
+			var (
+				projectState string
+			)
+			JustBeforeEach(func() {
+				mockGCPClient.EXPECT().ListProjects().Return([]*cloudresourcemanager.Project{{LifecycleState: projectState, ProjectId: projectReference.Spec.GCPProjectID}}, nil)
+			})
+			BeforeEach(func() {
+				projectReference.Spec.GCPProjectID = "fake-id"
+				projectState = "ACTIVE"
+			})
 			Context("When the lifecycleStatus is unknown", func() {
+				BeforeEach(func() {
+					projectState = "UNKNOWN"
+				})
 				It("returns an error", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "fake", ProjectId: projectReference.Spec.GCPProjectID}, nil)
 					err := adapter.EnsureProjectCleanedUp()
 					Expect(err).To(HaveOccurred())
 				})
 			})
 			Context("When the lifecycleStatus is LIFECYCLE_STATE_UNSPECIFIED", func() {
+				BeforeEach(func() {
+					projectState = "LIFECYCLE_STATE_UNSPECIFIED"
+				})
 				It("returns an error", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "LIFECYCLE_STATE_UNSPECIFIED", ProjectId: projectReference.Spec.GCPProjectID}, nil)
 					err := adapter.EnsureProjectCleanedUp()
 					Expect(err).To(HaveOccurred())
 				})
 			})
 			Context("When the lifecycleStatus is DELETE_REQUESTED", func() {
+				BeforeEach(func() {
+					projectState = "DELETE_REQUESTED"
+				})
 				It("deletes the project", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "DELETE_REQUESTED", ProjectId: projectReference.Spec.GCPProjectID}, nil)
 					mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, v1.Secret{}).Times(2)
 					mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(1)
 					err := adapter.EnsureProjectCleanedUp()
@@ -351,7 +367,6 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 			})
 			Context("When the lifecycleStatus is ACTIVE", func() {
 				It("deletes the project", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
 					mockGCPClient.EXPECT().DeleteProject(gomock.Any()).Times(1)
 					mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, v1.Secret{}).Times(2)
 					mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(1)
@@ -361,7 +376,6 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 			})
 			Context("When it cannot delete the project", func() {
 				It("returns an error", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
 					mockGCPClient.EXPECT().DeleteProject(gomock.Any()).Times(1)
 					mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, v1.Secret{}).Times(2)
 					mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(errors.New("Cannot delete the project"))

--- a/pkg/controller/projectreference/projectreference_controller.go
+++ b/pkg/controller/projectreference/projectreference_controller.go
@@ -99,12 +99,6 @@ func (r *ReconcileProjectReference) Reconcile(request reconcile.Request) (reconc
 		return r.requeueOnErr(err)
 	}
 
-	// If ProjectReference is in error state exit and do nothing
-	if projectReference.Status.State == gcpv1alpha1.ProjectReferenceStatusError {
-		reqLogger.Info("ProjectReference CR is in an Error state")
-		return r.doNotRequeue()
-	}
-
 	gcpClient, err := r.getGcpClient(projectReference.Spec.GCPProjectID, reqLogger)
 	if err != nil {
 		return r.requeueOnErr(err)
@@ -122,6 +116,12 @@ func (r *ReconcileProjectReference) Reconcile(request reconcile.Request) (reconc
 		if err != nil {
 			return r.requeueAfter(5*time.Second, err)
 		}
+		return r.doNotRequeue()
+	}
+
+	// If ProjectReference is in error state exit and do nothing
+	if projectReference.Status.State == gcpv1alpha1.ProjectReferenceStatusError {
+		reqLogger.Info("ProjectReference CR is in an Error state")
 		return r.doNotRequeue()
 	}
 


### PR DESCRIPTION
* otherwise ProjectReference in Error state is stuck in deletion
* ProjectClaim is stuck in deletion as well as ProjectReference never gets removed
* If project doesn't exist during deletion or ProjectId is empty,
  deletion doesn't get stuck