### PR TITLE
[WIP] 2995 supported region check in projectclaim

### DIFF
--- a/pkg/controller/projectclaim/projectclaim_controller.go
+++ b/pkg/controller/projectclaim/projectclaim_controller.go
@@ -25,6 +25,7 @@ type CustomResourceAdapter interface {
 	ProjectReferenceExists() (bool, error)
 	EnsureProjectClaimInitialized() (ObjectState, error)
 	EnsureProjectClaimState(gcpv1alpha1.ClaimStatus) error
+	CheckRequirements() error
 	EnsureProjectReferenceExists() error
 	EnsureProjectReferenceLink() (ObjectState, error)
 	EnsureFinalizer() (ObjectState, error)
@@ -113,6 +114,11 @@ func (r *ReconcileProjectClaim) ReconcileHandler(adapter CustomResourceAdapter) 
 			return r.requeueAfter(5*time.Second, err)
 		}
 		return r.doNotRequeue()
+	}
+
+	err := adapter.CheckRequirements()
+	if err != nil {
+		return r.requeueOnErr(err)
 	}
 
 	crState, err := adapter.EnsureProjectClaimInitialized()

--- a/pkg/controller/projectreference/projectreference_adapter.go
+++ b/pkg/controller/projectreference/projectreference_adapter.go
@@ -293,13 +293,6 @@ func (r *ReferenceAdapter) clearProjectID() error {
 	return r.kubeClient.Update(context.TODO(), r.ProjectReference)
 }
 
-func (r *ReferenceAdapter) CheckRequirements() error {
-	if _, ok := supportedRegions[r.ProjectClaim.Spec.Region]; !ok {
-		return operrors.ErrRegionNotSupported
-	}
-	return nil
-}
-
 // deleteProject checks the Project's lifecycle state of the projectReference.Spec.GCPProjectID instance in Google GCP
 // and deletes it if not active
 func (r *ReferenceAdapter) deleteProject() error {

--- a/pkg/controller/projectreference/projectreference_controller.go
+++ b/pkg/controller/projectreference/projectreference_controller.go
@@ -2,7 +2,6 @@ package projectreference
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -151,32 +150,6 @@ func (r *ReconcileProjectReference) ReconcileHandler(adapter *ReferenceAdapter, 
 	//only make changes to ProjectReference if ProjelctClaim is pending
 	if adapter.ProjectClaim.Status.State != gcpv1alpha1.ClaimStatusPendingProject {
 		return r.requeueAfter(5*time.Second, nil)
-	}
-
-	// make sure we meet mimimum requirements to process request and set its state to creating or error if its not supported
-	if adapter.ProjectReference.Status.State == "" {
-		reqLogger.Info("Checking Requirements")
-		err := adapter.CheckRequirements()
-		if err != nil {
-			// TODO: add condition here SupportedRegion = false to give more information on the error state
-			reqLogger.Error(err, "Region not supported")
-			adapter.ProjectReference.Status.State = gcpv1alpha1.ProjectReferenceStatusError
-			err := r.client.Status().Update(context.TODO(), adapter.ProjectReference)
-			if err != nil {
-				reqLogger.Error(err, "Error updating ProjectReference Status")
-				return r.requeueOnErr(err)
-			}
-			return r.doNotRequeue()
-		}
-
-		reqLogger.Info(fmt.Sprintf("Setting ProjectReferenceStatus %s", gcpv1alpha1.ProjectReferenceStatusCreating))
-		// passed requirementes check set to creating
-		adapter.ProjectReference.Status.State = gcpv1alpha1.ProjectReferenceStatusCreating
-		err = r.client.Status().Update(context.TODO(), adapter.ProjectReference)
-		if err != nil {
-			reqLogger.Error(err, "Error updating ProjectReference Status")
-			return r.requeueOnErr(err)
-		}
 	}
 
 	if adapter.ProjectReference.Spec.GCPProjectID == "" {


### PR DESCRIPTION
[OSD-2995](https://issues.redhat.com/browse/OSD-2995)

**Scenarios:**
1) User starts operator with wrong region. Result -> ..."msg":"Region is not supported"...
2) User fixes the region while operator is running. Result -> Operator is stuck in ..."msg":"Reconciling ProjectClaim"...
3) User stops operator, fixes region, starts operator again. Result -> ..."msg":"ProjectReference and ProjectClaim CR are in READY state nothing to process."...

**Next steps:**
I need to figure out why in 2nd scenario operator is stuck in "Reconciling ProjectClaim" state.