### PR TITLE
Supported region check in ProjectClaim

### DIFF
--- a/pkg/controller/projectclaim/projectclaim_controller.go
+++ b/pkg/controller/projectclaim/projectclaim_controller.go
@@ -25,6 +25,7 @@ type CustomResourceAdapter interface {
 	ProjectReferenceExists() (bool, error)
 	EnsureProjectClaimInitialized() (ObjectState, error)
 	EnsureProjectClaimState(gcpv1alpha1.ClaimStatus) error
+	EnsureRegionSupported() error
 	EnsureProjectReferenceExists() error
 	EnsureProjectReferenceLink() (ObjectState, error)
 	EnsureFinalizer() (ObjectState, error)
@@ -117,6 +118,11 @@ func (r *ReconcileProjectClaim) ReconcileHandler(adapter CustomResourceAdapter) 
 
 	crState, err := adapter.EnsureProjectClaimInitialized()
 	if crState == ObjectModified || err != nil {
+		return r.requeueOnErr(err)
+	}
+
+	err = adapter.EnsureRegionSupported()
+	if err != nil {
 		return r.requeueOnErr(err)
 	}
 

--- a/pkg/controller/projectclaim/projectclaim_controller_test.go
+++ b/pkg/controller/projectclaim/projectclaim_controller_test.go
@@ -72,6 +72,7 @@ var _ = Describe("ProjectclaimController", func() {
 		Context("When the ProjectClaim is newly created", func() {
 			BeforeEach(func() {
 				mockAdapter = mockclaim.NewMockCustomResourceAdapter(mockCtrl)
+				mockAdapter.EXPECT().EnsureRegionSupported().Return(nil)
 				mockAdapter.EXPECT().EnsureProjectReferenceExists().Return(nil)
 				mockAdapter.EXPECT().IsProjectClaimDeletion().Return(false)
 				mockAdapter.EXPECT().EnsureProjectClaimInitialized().Return(ObjectUnchanged, nil)

--- a/pkg/controller/projectclaim/projectclaimadapter_test.go
+++ b/pkg/controller/projectclaim/projectclaimadapter_test.go
@@ -82,6 +82,30 @@ var _ = Describe("Customresourceadapter", func() {
 		})
 	})
 
+	Context("When the EnsureRegionSupported() is called", func() {
+		Context("if the projectclaim has a supported region", func() {
+			BeforeEach(func() {
+				projectClaim.Spec.Region = "us-east1"
+			})
+			It("should return nil", func() {
+				err := adapter.EnsureRegionSupported()
+				Expect(err).To(BeNil())
+			})
+		})
+		Context("if the projectclaim has an unsupported region", func() {
+			BeforeEach(func() {
+				matcher := testStructs.NewProjectClaimMatcher()
+				mockClient.EXPECT().Status().Return(mockStatusWriter)
+				mockStatusWriter.EXPECT().Update(gomock.Any(), matcher)
+				projectClaim.Spec.Region = "fake-region"
+			})
+			It("should return err", func() {
+				err := adapter.EnsureRegionSupported()
+				Expect(err).To(Equal(er.New("EnsureRegionSupported: RegionNotSupported")))
+			})
+		})
+	})
+
 	Context("FinalizeProjectClaim", func() {
 		var (
 			matcher *testStructs.ProjectClaimMatcher

--- a/pkg/controller/projectreference/projectreference_adapter.go
+++ b/pkg/controller/projectreference/projectreference_adapter.go
@@ -64,37 +64,6 @@ var OSDRequiredRoles = []string{
 	"roles/compute.admin",
 }
 
-// Regions supported in the gcp-project-operator
-var supportedRegions = map[string]bool{
-	"asia-east1":      true,
-	"asia-northeast1": true,
-	"asia-southeast1": true,
-	"europe-west1":    true,
-	"europe-west4":    true,
-	"us-central1":     true,
-	"us-east1":        true,
-	"us-east4":        true,
-	"us-west1":        true,
-
-	// Regions below don't have enough quota configured by default, but our org has sufficient quota
-	"asia-east2":   true,
-	"asia-south1":  true,
-	"europe-west2": true,
-	"us-west2":     true,
-
-	// Regions below have enough quota, but the region name will produce too long hostnames.
-	// This is an issue the openshift installer needs to fix.
-	// "australia-southeast1":    true,
-	// "northamerica-northeast1": true,
-	// "southamerica-east1":      true,
-
-	// Regions below are disabled do not have enough quota configured (CPU < 28 or SSD storage < 896)
-	// "europe-west3":            true,
-	// "europe-west6":            true,
-	// "europe-north1":           true,
-	// "asia-northeast2":         true,
-}
-
 //ReferenceAdapter is used to do all the processing of the ProjectReference type inside the reconcile loop
 type ReferenceAdapter struct {
 	ProjectClaim     *gcpv1alpha1.ProjectClaim
@@ -291,13 +260,6 @@ func GenerateProjectID() (string, error) {
 func (r *ReferenceAdapter) clearProjectID() error {
 	r.ProjectReference.Spec.GCPProjectID = ""
 	return r.kubeClient.Update(context.TODO(), r.ProjectReference)
-}
-
-func (r *ReferenceAdapter) CheckRequirements() error {
-	if _, ok := supportedRegions[r.ProjectClaim.Spec.Region]; !ok {
-		return operrors.ErrRegionNotSupported
-	}
-	return nil
 }
 
 // deleteProject checks the Project's lifecycle state of the projectReference.Spec.GCPProjectID instance in Google GCP

--- a/pkg/controller/projectreference/projectreference_adapter_test.go
+++ b/pkg/controller/projectreference/projectreference_adapter_test.go
@@ -12,7 +12,6 @@ import (
 	gcpv1alpha1 "github.com/openshift/gcp-project-operator/pkg/apis/gcp/v1alpha1"
 	mockconditions "github.com/openshift/gcp-project-operator/pkg/condition/mock"
 	. "github.com/openshift/gcp-project-operator/pkg/controller/projectreference"
-	operrors "github.com/openshift/gcp-project-operator/pkg/util/errors"
 	mocks "github.com/openshift/gcp-project-operator/pkg/util/mocks"
 	mockGCP "github.com/openshift/gcp-project-operator/pkg/util/mocks/gcpclient"
 	testStructs "github.com/openshift/gcp-project-operator/pkg/util/mocks/structs"
@@ -421,28 +420,6 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 					mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(errors.New("Cannot delete the project"))
 					err := adapter.EnsureProjectCleanedUp()
 					Expect(err).To(HaveOccurred())
-				})
-			})
-		})
-
-		Context("CheckRequirements", func() {
-			Context("When the region is supported", func() {
-				BeforeEach(func() {
-					projectClaim.Spec.Region = "us-east1"
-				})
-				It("does not return an error", func() {
-					err := adapter.CheckRequirements()
-					Expect(err).NotTo(HaveOccurred())
-				})
-			})
-			Context("When the region is not supported", func() {
-				BeforeEach(func() {
-					projectClaim.Spec.Region = "eu-west6"
-				})
-				It("does not return an error", func() {
-					err := adapter.CheckRequirements()
-					Expect(err).To(HaveOccurred())
-					Expect(err).To(Equal(operrors.ErrRegionNotSupported))
 				})
 			})
 		})

--- a/pkg/util/mocks/projectclaim/customeresourceadapter.go
+++ b/pkg/util/mocks/projectclaim/customeresourceadapter.go
@@ -5,11 +5,10 @@
 package projectclaim
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/openshift/gcp-project-operator/pkg/apis/gcp/v1alpha1"
 	projectclaim "github.com/openshift/gcp-project-operator/pkg/controller/projectclaim"
+	reflect "reflect"
 )
 
 // MockCustomResourceAdapter is a mock of CustomResourceAdapter interface
@@ -106,6 +105,20 @@ func (m *MockCustomResourceAdapter) EnsureProjectReferenceLink() (projectclaim.O
 func (mr *MockCustomResourceAdapterMockRecorder) EnsureProjectReferenceLink() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureProjectReferenceLink", reflect.TypeOf((*MockCustomResourceAdapter)(nil).EnsureProjectReferenceLink))
+}
+
+// EnsureRegionSupported mocks base method
+func (m *MockCustomResourceAdapter) EnsureRegionSupported() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureRegionSupported")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureRegionSupported indicates an expected call of EnsureRegionSupported
+func (mr *MockCustomResourceAdapterMockRecorder) EnsureRegionSupported() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureRegionSupported", reflect.TypeOf((*MockCustomResourceAdapter)(nil).EnsureRegionSupported))
 }
 
 // FinalizeProjectClaim mocks base method


### PR DESCRIPTION
[Jira card: OSD-2995](https://issues.redhat.com/browse/OSD-2995)

**Scenarios:**
1) User starts operator with wrong region. Result -> ..."msg":"Region is not supported"...
2) User fixes the region while operator is running. Result -> Operator is stuck in ..."msg":"Reconciling ProjectClaim"...
3) User stops operator, fixes region, starts operator again. Result -> ..."msg":"ProjectReference and ProjectClaim CR are in READY state nothing to process."...

**Next steps:**
I need to figure out why in 2nd scenario operator is stuck in "Reconciling ProjectClaim" state.