### PR TITLE
docs(contributing): fix link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,10 +24,10 @@ If you are new to open-source contribution, please read the this [guide](https:/
 
 ## Writing tests
 
-As a best practice, the project requires tests to be submitted at the same PR with the code. If you are developing a new feature, please remember writting tests for it as well. See the relevant [testing documenation](./docs/testing.md)
+As a best practice, the project requires tests to be submitted at the same PR with the code. If you are developing a new feature, please remember writting tests for it as well. See the relevant [testing documenation](./testing.md)
 
 ## An example PR template
 
-Here is a [PR template](./docs/PULL_REQUEST_TEMPLATE.md) which can be used by contributors. 
+Here is a [PR template](./PULL_REQUEST_TEMPLATE.md) which can be used by contributors. 
 After having both `/lgtm` and `/approve` labels from approvers and reviewers, your PR will be merged by `Openshift Merge Bot`
 To prevent any accidental merge, marking the PR as `work in progress` by adding the `[WIP]` tag would be nice


### PR DESCRIPTION
### What type of PR is this? 
docs

### What this PR does / why we need it:
typo at pr template link in `docs/CONTRIBUTING.md`

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
none

### Special notes for your reviewer:
none

### Is it a breaking change or backward compatible?
none

### Pre-checks:
- [x] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage