### PR TITLE
Remove ProjectReference superfluous logs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/gcp-project-operator/pkg/apis"
 	"github.com/openshift/gcp-project-operator/pkg/controller"
+	logtypes "github.com/openshift/gcp-project-operator/pkg/util/types"
 
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -32,9 +33,9 @@ var (
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+	log.V(logtypes.OperatorSDK).Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	log.V(logtypes.OperatorSDK).Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	log.V(logtypes.OperatorSDK).Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
 }
 
 func main() {
@@ -95,7 +96,7 @@ func run() error {
 		return err
 	}
 
-	log.Info("Registering Components.")
+	log.V(logtypes.OperatorSDK).Info("Registering Components.")
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
@@ -112,15 +113,15 @@ func run() error {
 	// Create Service object to expose the metrics port.
 	_, err = metrics.ExposeMetricsPort(ctx, metricsPort)
 	if err != nil {
-		log.Info(err.Error())
+		log.V(logtypes.OperatorSDK).Info(err.Error())
 	}
 
 	// start cache and wait for sync
-	log.Info("init chache")
+	log.V(logtypes.OperatorSDK).Info("init chache")
 	cache := mgr.GetCache()
 	go cache.Start(stopCh)
 	cache.WaitForCacheSync(stopCh)
-	log.Info("Starting the Cmd.")
+	log.V(logtypes.OperatorSDK).Info("Starting the Cmd.")
 
 	// Start the Cmd
 	return mgr.Start(stopCh)

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -2,6 +2,32 @@
 
 Some useful commands:
 
+### Log verbosity
+
+You can modify the verbosity by adding `args:`to the [operator.yaml](../deploy/operator.yaml)
+
+If you want to see `info` logs coming from the `ProjectReference` use `--zap-level=X`, where X can be:
+
+1. ProjectReference logs
+2. ProjectClaim logs
+3. gcp client logs
+4. operator-sdk logs (golang version, etc)
+
+as described in the type [ComponentLogLevel](../pkg/util/types/comonentloglevel.go)
+
+e.g. if you are interested only in error messages, you can do it like this:
+
+```yaml
+      containers:
+        - name: gcp-project-operator
+          image: quay.io/app-sre/gcp-project-operator
+          command:
+          - gcp-project-operator
+          args:
+          - '--zap-level=error'
+          imagePullPolicy: Always
+```
+
 ### ProjectClaim
 
 The `ProjectClaim` is getting deployed onto a namespace defined at the Resource.

--- a/docs/development.md
+++ b/docs/development.md
@@ -37,7 +37,7 @@ The operator can run either:
 
 No matter which option you choose, before running the Operator you have to create the following Custom Resource Definitions on the cluster:
 
-```zsh
+```shell
 kubectl create -f deploy/crds/gcp_v1alpha1_projectclaim_crd.yaml
 kubectl create -f deploy/crds/gcp_v1alpha1_projectreference_crd.yaml
 ```
@@ -46,12 +46,23 @@ kubectl create -f deploy/crds/gcp_v1alpha1_projectreference_crd.yaml
 
 Make sure you have the [operator-sdk](https://github.com/operator-framework/operator-sdk/releases) binary in your `$PATH` and run it locally:
 
-```zsh
+```shell
 $ operator-sdk run --local --namespace gcp-project-operator
 ```
 
 You will see some initialization logs.
 The Operator will remain _idle_ after that, waiting for `ProjectClaim` resources to be present in the cluster.
+
+You can change the verbosity of the logs, by passing the `--zap-level` flag as part of the `--operator-flags`:
+
+```shell
+run --local --namespace gcp-project-operator --operator-flags --zap-level=99
+```
+
+* Level 1: ProjectReference
+* Level 2: ProjectClaim
+* Level 3: gcpclient
+* Level 4: operator-sdk framrwork logs (golang version, etc)
 
 ### Remotely
 
@@ -59,7 +70,7 @@ The Operator will remain _idle_ after that, waiting for `ProjectClaim` resources
 
 Push the image to your container registry of your choice. For example:
 
-```bash
+```shell
 username="razevedo"
 podman build . -f build/Dockerfile -t "quay.io/$username/gcp-project-operator"
 podman push "quay.io/$username/gcp-project-operator"
@@ -85,7 +96,7 @@ kubectl scale deployment gcp-project-operator -n gcp-project-operator --replicas
 
 Otherwise, you can directly upload the image to your kubernetes cluster by hand
 
-```zsh
+```shell
 # Export the image locally
 docker save $image-name > image-name.tar
 

--- a/pkg/controller/projectclaim/projectclaim_controller.go
+++ b/pkg/controller/projectclaim/projectclaim_controller.go
@@ -79,7 +79,6 @@ func NewReconcileProjectClaim(client client.Client, scheme *runtime.Scheme) *Rec
 // Reconcile calls ReconcileHandler and updates the CRD if any err occurs
 func (r *ReconcileProjectClaim) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling ProjectClaim")
 
 	// Fetch the ProjectClaim instance
 	instance := &gcpv1alpha1.ProjectClaim{}

--- a/pkg/controller/projectclaim/projectclaimadapter.go
+++ b/pkg/controller/projectclaim/projectclaimadapter.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/openshift/cluster-api/pkg/util"
+	logtypes "github.com/openshift/gcp-project-operator/pkg/util/types"
+
 	gcpv1alpha1 "github.com/openshift/gcp-project-operator/pkg/apis/gcp/v1alpha1"
 	condition "github.com/openshift/gcp-project-operator/pkg/condition"
 	operrors "github.com/openshift/gcp-project-operator/pkg/util/errors"
@@ -175,7 +177,7 @@ func (c *ProjectClaimAdapter) EnsureProjectReferenceLink() (ObjectState, error) 
 
 func (c *ProjectClaimAdapter) EnsureFinalizer() (ObjectState, error) {
 	if !util.Contains(c.projectClaim.GetFinalizers(), ProjectClaimFinalizer) {
-		c.logger.Info("Adding Finalizer to the ProjectClaim")
+		c.logger.V(int(logtypes.ProjectClaim)).Info("Adding Finalizer to the ProjectClaim")
 		c.projectClaim.SetFinalizers(append(c.projectClaim.GetFinalizers(), ProjectClaimFinalizer))
 
 		err := c.client.Update(context.TODO(), c.projectClaim)

--- a/pkg/controller/projectreference/projectreference_controller.go
+++ b/pkg/controller/projectreference/projectreference_controller.go
@@ -9,6 +9,7 @@ import (
 	condition "github.com/openshift/gcp-project-operator/pkg/condition"
 	"github.com/openshift/gcp-project-operator/pkg/gcpclient"
 	"github.com/openshift/gcp-project-operator/pkg/util"
+	logtypes "github.com/openshift/gcp-project-operator/pkg/util/types"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,7 +82,6 @@ type ReconcileProjectReference struct {
 // Reconcile wraps ReconcileHandler() and updates the conditions if any error occurs
 func (r *ReconcileProjectReference) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling ProjectReference")
 
 	projectReference := &gcpv1alpha1.ProjectReference{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, projectReference)
@@ -156,7 +156,7 @@ func (r *ReconcileProjectReference) ReconcileHandler(adapter *ReferenceAdapter, 
 	}
 
 	if adapter.ProjectReference.Spec.GCPProjectID == "" {
-		reqLogger.Info("Creating ProjectID in ProjectReference CR")
+		reqLogger.V(int(logtypes.ProjectReference)).Info("Creating ProjectID in ProjectReference CR")
 		err := adapter.UpdateProjectID()
 		if err != nil {
 			reqLogger.Error(err, "Could not update ProjectID in Project Reference CR")
@@ -165,14 +165,14 @@ func (r *ReconcileProjectReference) ReconcileHandler(adapter *ReferenceAdapter, 
 		return r.requeue()
 	}
 
-	reqLogger.Info("Adding a Finalizer")
+	reqLogger.V(int(logtypes.ProjectReference)).Info("Adding a Finalizer")
 	err = adapter.EnsureFinalizerAdded()
 	if err != nil {
 		reqLogger.Error(err, "Error adding the finalizer")
 		return r.requeueOnErr(err)
 	}
 
-	reqLogger.Info("Configuring Project")
+	reqLogger.V(int(logtypes.ProjectReference)).Info("Configuring Project")
 	err = adapter.EnsureProjectConfigured()
 	if err != nil {
 		return r.requeueAfter(5*time.Second, err)

--- a/pkg/gcpclient/client.go
+++ b/pkg/gcpclient/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	logtypes "github.com/openshift/gcp-project-operator/pkg/util/types"
 	"golang.org/x/oauth2/google"
 	cloudbilling "google.golang.org/api/cloudbilling/v1"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
@@ -157,7 +158,7 @@ func (c *gcpClient) GetProject(projectID string) (*cloudresourcemanager.Project,
 
 // CreateProject creates a project in a given folder.
 func (c *gcpClient) CreateProject(parentFolderID string) (*cloudresourcemanager.Operation, error) {
-	log.Info("gcpClient.CreateProject")
+	log.V(logtypes.GCPClient).Info("gcpClient.CreateProject")
 	project := cloudresourcemanager.Project{
 		//Labels:          nil,
 		Name: c.projectName,
@@ -281,7 +282,7 @@ func (c *gcpClient) SetIamPolicy(setIamPolicyRequest *cloudresourcemanager.SetIa
 }
 
 func (c *gcpClient) EnableAPI(projectID, api string) error {
-	log.Info(fmt.Sprintf("enable %s api", api))
+	log.V(logtypes.GCPClient).Info(fmt.Sprintf("enable %s api", api))
 	enableServicerequest := &serviceManagment.EnableServiceRequest{
 		ConsumerId: fmt.Sprintf("project:%s", projectID),
 	}
@@ -302,7 +303,7 @@ func (c *gcpClient) EnableAPI(projectID, api string) error {
 			// creation is completed and marked as Done.
 			// Something is not propagating in the backend.
 			if ok && ae.Code == http.StatusForbidden && retry <= gcpAPIRetriesCount {
-				log.Info(fmt.Sprintf("retry %d for enable %s api", retry, api))
+				log.V(logtypes.GCPClient).Info(fmt.Sprintf("retry %d for enable %s api", retry, api))
 				continue
 			}
 			return err

--- a/pkg/util/mocks/gcpclient/client.go
+++ b/pkg/util/mocks/gcpclient/client.go
@@ -5,37 +5,36 @@
 package gcpclient
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	iam "google.golang.org/api/iam/v1"
+	reflect "reflect"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// GetServiceAccount mocks base method
+// GetServiceAccount mocks base method.
 func (m *MockClient) GetServiceAccount(accountName string) (*iam.ServiceAccount, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceAccount", accountName)
@@ -44,13 +43,13 @@ func (m *MockClient) GetServiceAccount(accountName string) (*iam.ServiceAccount,
 	return ret0, ret1
 }
 
-// GetServiceAccount indicates an expected call of GetServiceAccount
+// GetServiceAccount indicates an expected call of GetServiceAccount.
 func (mr *MockClientMockRecorder) GetServiceAccount(accountName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceAccount", reflect.TypeOf((*MockClient)(nil).GetServiceAccount), accountName)
 }
 
-// CreateServiceAccount mocks base method
+// CreateServiceAccount mocks base method.
 func (m *MockClient) CreateServiceAccount(name, displayName string) (*iam.ServiceAccount, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateServiceAccount", name, displayName)
@@ -59,13 +58,13 @@ func (m *MockClient) CreateServiceAccount(name, displayName string) (*iam.Servic
 	return ret0, ret1
 }
 
-// CreateServiceAccount indicates an expected call of CreateServiceAccount
+// CreateServiceAccount indicates an expected call of CreateServiceAccount.
 func (mr *MockClientMockRecorder) CreateServiceAccount(name, displayName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceAccount", reflect.TypeOf((*MockClient)(nil).CreateServiceAccount), name, displayName)
 }
 
-// DeleteServiceAccount mocks base method
+// DeleteServiceAccount mocks base method.
 func (m *MockClient) DeleteServiceAccount(accountEmail string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServiceAccount", accountEmail)
@@ -73,13 +72,13 @@ func (m *MockClient) DeleteServiceAccount(accountEmail string) error {
 	return ret0
 }
 
-// DeleteServiceAccount indicates an expected call of DeleteServiceAccount
+// DeleteServiceAccount indicates an expected call of DeleteServiceAccount.
 func (mr *MockClientMockRecorder) DeleteServiceAccount(accountEmail interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceAccount", reflect.TypeOf((*MockClient)(nil).DeleteServiceAccount), accountEmail)
 }
 
-// CreateServiceAccountKey mocks base method
+// CreateServiceAccountKey mocks base method.
 func (m *MockClient) CreateServiceAccountKey(serviceAccountEmail string) (*iam.ServiceAccountKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateServiceAccountKey", serviceAccountEmail)
@@ -88,13 +87,13 @@ func (m *MockClient) CreateServiceAccountKey(serviceAccountEmail string) (*iam.S
 	return ret0, ret1
 }
 
-// CreateServiceAccountKey indicates an expected call of CreateServiceAccountKey
+// CreateServiceAccountKey indicates an expected call of CreateServiceAccountKey.
 func (mr *MockClientMockRecorder) CreateServiceAccountKey(serviceAccountEmail interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceAccountKey", reflect.TypeOf((*MockClient)(nil).CreateServiceAccountKey), serviceAccountEmail)
 }
 
-// DeleteServiceAccountKeys mocks base method
+// DeleteServiceAccountKeys mocks base method.
 func (m *MockClient) DeleteServiceAccountKeys(serviceAccountEmail string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServiceAccountKeys", serviceAccountEmail)
@@ -102,13 +101,13 @@ func (m *MockClient) DeleteServiceAccountKeys(serviceAccountEmail string) error 
 	return ret0
 }
 
-// DeleteServiceAccountKeys indicates an expected call of DeleteServiceAccountKeys
+// DeleteServiceAccountKeys indicates an expected call of DeleteServiceAccountKeys.
 func (mr *MockClientMockRecorder) DeleteServiceAccountKeys(serviceAccountEmail interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceAccountKeys", reflect.TypeOf((*MockClient)(nil).DeleteServiceAccountKeys), serviceAccountEmail)
 }
 
-// GetIamPolicy mocks base method
+// GetIamPolicy mocks base method.
 func (m *MockClient) GetIamPolicy(projectName string) (*cloudresourcemanager.Policy, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIamPolicy", projectName)
@@ -117,13 +116,13 @@ func (m *MockClient) GetIamPolicy(projectName string) (*cloudresourcemanager.Pol
 	return ret0, ret1
 }
 
-// GetIamPolicy indicates an expected call of GetIamPolicy
+// GetIamPolicy indicates an expected call of GetIamPolicy.
 func (mr *MockClientMockRecorder) GetIamPolicy(projectName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIamPolicy", reflect.TypeOf((*MockClient)(nil).GetIamPolicy), projectName)
 }
 
-// SetIamPolicy mocks base method
+// SetIamPolicy mocks base method.
 func (m *MockClient) SetIamPolicy(setIamPolicyRequest *cloudresourcemanager.SetIamPolicyRequest) (*cloudresourcemanager.Policy, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetIamPolicy", setIamPolicyRequest)
@@ -132,13 +131,13 @@ func (m *MockClient) SetIamPolicy(setIamPolicyRequest *cloudresourcemanager.SetI
 	return ret0, ret1
 }
 
-// SetIamPolicy indicates an expected call of SetIamPolicy
+// SetIamPolicy indicates an expected call of SetIamPolicy.
 func (mr *MockClientMockRecorder) SetIamPolicy(setIamPolicyRequest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIamPolicy", reflect.TypeOf((*MockClient)(nil).SetIamPolicy), setIamPolicyRequest)
 }
 
-// ListProjects mocks base method
+// ListProjects mocks base method.
 func (m *MockClient) ListProjects() ([]*cloudresourcemanager.Project, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListProjects")
@@ -147,13 +146,13 @@ func (m *MockClient) ListProjects() ([]*cloudresourcemanager.Project, error) {
 	return ret0, ret1
 }
 
-// ListProjects indicates an expected call of ListProjects
+// ListProjects indicates an expected call of ListProjects.
 func (mr *MockClientMockRecorder) ListProjects() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProjects", reflect.TypeOf((*MockClient)(nil).ListProjects))
 }
 
-// CreateProject mocks base method
+// CreateProject mocks base method.
 func (m *MockClient) CreateProject(parentFolder string) (*cloudresourcemanager.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateProject", parentFolder)
@@ -162,13 +161,13 @@ func (m *MockClient) CreateProject(parentFolder string) (*cloudresourcemanager.O
 	return ret0, ret1
 }
 
-// CreateProject indicates an expected call of CreateProject
+// CreateProject indicates an expected call of CreateProject.
 func (mr *MockClientMockRecorder) CreateProject(parentFolder interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProject", reflect.TypeOf((*MockClient)(nil).CreateProject), parentFolder)
 }
 
-// DeleteProject mocks base method
+// DeleteProject mocks base method.
 func (m *MockClient) DeleteProject(parentFolder string) (*cloudresourcemanager.Empty, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteProject", parentFolder)
@@ -177,13 +176,13 @@ func (m *MockClient) DeleteProject(parentFolder string) (*cloudresourcemanager.E
 	return ret0, ret1
 }
 
-// DeleteProject indicates an expected call of DeleteProject
+// DeleteProject indicates an expected call of DeleteProject.
 func (mr *MockClientMockRecorder) DeleteProject(parentFolder interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProject", reflect.TypeOf((*MockClient)(nil).DeleteProject), parentFolder)
 }
 
-// GetProject mocks base method
+// GetProject mocks base method.
 func (m *MockClient) GetProject(projectID string) (*cloudresourcemanager.Project, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProject", projectID)
@@ -192,13 +191,13 @@ func (m *MockClient) GetProject(projectID string) (*cloudresourcemanager.Project
 	return ret0, ret1
 }
 
-// GetProject indicates an expected call of GetProject
+// GetProject indicates an expected call of GetProject.
 func (mr *MockClientMockRecorder) GetProject(projectID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockClient)(nil).GetProject), projectID)
 }
 
-// EnableAPI mocks base method
+// EnableAPI mocks base method.
 func (m *MockClient) EnableAPI(projectID, api string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableAPI", projectID, api)
@@ -206,13 +205,13 @@ func (m *MockClient) EnableAPI(projectID, api string) error {
 	return ret0
 }
 
-// EnableAPI indicates an expected call of EnableAPI
+// EnableAPI indicates an expected call of EnableAPI.
 func (mr *MockClientMockRecorder) EnableAPI(projectID, api interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableAPI", reflect.TypeOf((*MockClient)(nil).EnableAPI), projectID, api)
 }
 
-// CreateCloudBillingAccount mocks base method
+// CreateCloudBillingAccount mocks base method.
 func (m *MockClient) CreateCloudBillingAccount(projectID, billingAccount string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCloudBillingAccount", projectID, billingAccount)
@@ -220,13 +219,13 @@ func (m *MockClient) CreateCloudBillingAccount(projectID, billingAccount string)
 	return ret0
 }
 
-// CreateCloudBillingAccount indicates an expected call of CreateCloudBillingAccount
+// CreateCloudBillingAccount indicates an expected call of CreateCloudBillingAccount.
 func (mr *MockClientMockRecorder) CreateCloudBillingAccount(projectID, billingAccount interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCloudBillingAccount", reflect.TypeOf((*MockClient)(nil).CreateCloudBillingAccount), projectID, billingAccount)
 }
 
-// ListAvilibilityZones mocks base method
+// ListAvilibilityZones mocks base method.
 func (m *MockClient) ListAvilibilityZones(projectID, region string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAvilibilityZones", projectID, region)
@@ -235,7 +234,7 @@ func (m *MockClient) ListAvilibilityZones(projectID, region string) ([]string, e
 	return ret0, ret1
 }
 
-// ListAvilibilityZones indicates an expected call of ListAvilibilityZones
+// ListAvilibilityZones indicates an expected call of ListAvilibilityZones.
 func (mr *MockClientMockRecorder) ListAvilibilityZones(projectID, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAvilibilityZones", reflect.TypeOf((*MockClient)(nil).ListAvilibilityZones), projectID, region)

--- a/pkg/util/types/comonentloglevel.go
+++ b/pkg/util/types/comonentloglevel.go
@@ -1,0 +1,15 @@
+package types
+
+// ComponentLogLevel type is used in the logging function to assert the log level for components
+type ComponentLogLevel int
+
+const (
+	// ProjectReference is v1 verbose level
+	ProjectReference ComponentLogLevel = 1
+	// ProjectClaim is v2 verbose level
+	ProjectClaim = 2
+	// GCPClient is v3 verbose level
+	GCPClient = 3
+	//OperatorSDK is v4 verbose level
+	OperatorSDK = 4
+)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -56,6 +56,7 @@ func NewGCPSecretCR(creds string, namespacedNamed kubetypes.NamespacedName) *cor
 	}
 }
 
+// GetGCPCredentialsFromSecret extracts the gcp credentials from a secret. return value is a bytearray
 func GetGCPCredentialsFromSecret(kubeClient kubeclientpkg.Client, namespace, name string) ([]byte, error) {
 	secret := &corev1.Secret{}
 	err := kubeClient.Get(context.TODO(),
@@ -67,18 +68,18 @@ func GetGCPCredentialsFromSecret(kubeClient kubeclientpkg.Client, namespace, nam
 	if err != nil {
 		return []byte{}, fmt.Errorf("GetGCPCredentialsFromSecret.Get %v", err)
 	}
-	var osServiceAccountJson []byte
+	var osServiceAccountJSON []byte
 	var ok bool
-	osServiceAccountJson, ok = secret.Data["osServiceAccount.json"]
+	osServiceAccountJSON, ok = secret.Data["osServiceAccount.json"]
 	if !ok {
-		osServiceAccountJson, ok = secret.Data["key.json"]
+		osServiceAccountJSON, ok = secret.Data["key.json"]
 	}
 	if !ok {
 		return []byte{}, fmt.Errorf("GCP credentials secret %v did not contain key %v",
 			name, "{osServiceAccount,key}.json")
 	}
 
-	return osServiceAccountJson, nil
+	return osServiceAccountJSON, nil
 }
 
 // AddOrUpdateBinding checks if a binding from a map of bindings whose keys are the binding.Role exists in a list and if so it appends any new members to that binding.
@@ -135,6 +136,7 @@ func rolebindingMap(roles []string, member string) map[string]cloudresourcemanag
 	return requiredBindings
 }
 
+// InArray checks if a needle exists inside of the haystack
 func InArray(needle interface{}, haystack interface{}) (exists bool, index int) {
 	exists = false
 	index = -1


### PR DESCRIPTION
This PR does the following:

#### removes the following logs:

* Reconciling ProjectClaim/ProjectReference and the 'nothing to process'

```json
{"level":"info","ts":1587113163.1160336,"logger":"controller_projectclaim","msg":"Reconciling ProjectClaim","Request.Namespace":"<CLUSTER_NAMESPACE>","Request.Name":"<PROJECTCLAIM>"}`
{"level":"info","ts":1587113084.0763507,"logger":"controller_projectreference","msg":"Reconciling ProjectReference","Request.Namespace":"gcp-project-operator","Request.Name":"<PROJECTREFERENCE>"}
{"level":"info","ts":1587113084.0764222,"logger":"controller_projectreference","msg":"ProjectReference and ProjectClaim CR are in READY state nothing to process.","Request.Namespace":"gcp-project-operator","Request.Name":"<PROJECTREFERENCE>"}
```

#### Introduces 4 levels of verbosity

1. ProjectReference info logs
2. ProjectClaim info logs
3. gcpclient info logs
4. operators-sdk logs

#### Documentation is adapted

* How to change the log level in production 
* How to change the log level for development

## What happens now

### During setup

#### You don't see INFO messages. Only ERROR ones:

* controller_projectreference:
```json
{"level":"error","ts":1590567918.9430861,"logger":"controller_projectreference","msg":"Error creating credentials","Request.Namespace":"gcp-project-operator","Request.Name":"example-clusternamespace-example-projectclaim","error":"gcpclient.GetServiceAccount.Projects.ServiceAccounts.Get googleapi: Error 404: Service account projects/o-9df3882f/serviceAccounts/osd-managed-admin@o-9df3882f.iam.gserviceaccount.com does not exist., notFound","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReferenceAdapter).EnsureProjectConfigured\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_adapter.go:167\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReconcileProjectReference).ReconcileHandler\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_controller.go:175\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReconcileProjectReference).Reconcile\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_controller.go:109\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:215\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
{"level":"error","ts":1590567946.383595,"logger":"controller_projectreference","msg":"could not create service account","Request.Namespace":"gcp-project-operator","Request.Name":"example-clusternamespace-example-projectclaim","Service Account Name":"osd-managed-admin","error":"gcpclient.CreateServiceAccount.Projects.ServiceAccounts.Create googleapi: Error 409: Service account osd-managed-admin already exists within project projects/o-9df3882f., alreadyExists","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReferenceAdapter).configureServiceAccount\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_adapter.go:390\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReferenceAdapter).EnsureProjectConfigured\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_adapter.go:158\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReconcileProjectReference).ReconcileHandler\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_controller.go:175\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReconcileProjectReference).Reconcile\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_controller.go:109\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:215\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
{"level":"error","ts":1590567946.3839,"logger":"controller_projectreference","msg":"Error configuring service account","Request.Namespace":"gcp-project-operator","Request.Name":"example-clusternamespace-example-projectclaim","error":"gcpclient.CreateServiceAccount.Projects.ServiceAccounts.Create googleapi: Error 409: Service account osd-managed-admin already exists within project projects/o-9df3882f., alreadyExists","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReferenceAdapter).EnsureProjectConfigured\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_adapter.go:160\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReconcileProjectReference).ReconcileHandler\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_controller.go:175\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReconcileProjectReference).Reconcile\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_controller.go:109\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:215\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
{"level":"error","ts":1590567974.880117,"logger":"controller_projectreference","msg":"Error ensuring availability zones","Request.Namespace":"gcp-project-operator","Request.Name":"example-clusternamespace-example-projectclaim","error":"googleapi: Error 403: Access Not Configured. Compute Engine API has not been used in project 617591735564 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=617591735564 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReferenceAdapter).EnsureProjectClaimReady\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_adapter.go:104\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReconcileProjectReference).ReconcileHandler\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_controller.go:138\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReconcileProjectReference).Reconcile\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_controller.go:109\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:215\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

Kubebuilder:
```json
{"level":"error","ts":1590567918.947733,"logger":"kubebuilder.controller","msg":"Reconciler error","controller":"projectreference-controller","request":"gcp-project-operator/example-clusternamespace-example-projectclaim","error":"gcpclient.GetServiceAccount.Projects.ServiceAccounts.Get googleapi: Error 404: Service account projects/o-9df3882f/serviceAccounts/osd-managed-admin@o-9df3882f.iam.gserviceaccount.com does not exist., notFound","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:217\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
{"level":"error","ts":1590567946.388541,"logger":"kubebuilder.controller","msg":"Reconciler error","controller":"projectreference-controller","request":"gcp-project-operator/example-clusternamespace-example-projectclaim","error":"gcpclient.CreateServiceAccount.Projects.ServiceAccounts.Create googleapi: Error 409: Service account osd-managed-admin already exists within project projects/o-9df3882f., alreadyExists","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:217\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

### During deletion

#### You see both INFO and Error messages

* Project Reference INFO

```json
{"level":"info","ts":1590568337.6026628,"logger":"controller_projectreference","msg":"Deleting Project","Request.Namespace":"gcp-project-operator","Request.Name":"example-clusternamespace-example-projectclaim"}
{"level":"info","ts":1590568340.283775,"logger":"controller_projectreference","msg":"Deleting Credentials","Request.Namespace":"gcp-project-operator","Request.Name":"example-clusternamespace-example-projectclaim"}
{"level":"info","ts":1590568340.291747,"logger":"controller_projectreference","msg":"Deleting Finalizer","Request.Namespace":"gcp-project-operator","Request.Name":"example-clusternamespace-example-projectclaim"}
```

* Project Reference ERROR

```json
{"level":"error","ts":1590568340.30071,"logger":"controller_projectreference","msg":"failed to update ProjectClaim state for example-clusternamespace-example-projectclaim","Request.Namespace":"gcp-project-operator","Request.Name":"example-clusternamespace-example-projectclaim","error":"Operation cannot be fulfilled on projectreferences.gcp.managed.openshift.io \"example-clusternamespace-example-projectclaim\": StorageError: invalid object, Code: 4, Key: /kubernetes.io/gcp.managed.openshift.io/projectreferences/gcp-project-operator/example-clusternamespace-example-projectclaim, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: ee929475-0dee-4a7b-b515-59265d2edb47, UID in object meta: ","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReferenceAdapter).StatusUpdate\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_adapter.go:595\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReferenceAdapter).SetProjectReferenceCondition\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_adapter.go:588\ngithub.com/openshift/gcp-project-operator/pkg/controller/projectreference.(*ReconcileProjectReference).Reconcile\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/pkg/controller/projectreference/projectreference_controller.go:111\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:215\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/drpaneas/gocode/src/github.com/openshift/gcp-project-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

* ProjectClaim Info

```json
{"level":"info","ts":1590568340.5054772,"logger":"controller_projectclaim","msg":"Deleting Finalizer","Request.Namespace":"example-clusternamespace","Request.Name":"example-projectclaim"}
```