### PR TITLE
feat(operator-sdk): upgrade operator-sdk to latest 

### DIFF
--- a/deploy/crds/gcp_v1alpha1_projectclaim_crd.yaml
+++ b/deploy/crds/gcp_v1alpha1_projectclaim_crd.yaml
@@ -124,6 +124,11 @@ spec:
           - conditions
           - state
           type: object
+#      type: object # This line causes the CRD to stop working on openshift (last checked on 3.11.154)
+                    # The reason for that is the v1beta1 CRD api changed upstread and the tool
+                    # which generates this file `operator-sdk` uses the upstream api.
+                    # see issue https://github.com/jetstack/cert-manager/issues/2200
+      
   version: v1alpha1
   versions:
   - name: v1alpha1

--- a/deploy/crds/gcp_v1alpha1_projectreference_crd.yaml
+++ b/deploy/crds/gcp_v1alpha1_projectreference_crd.yaml
@@ -108,6 +108,10 @@ spec:
             state:
               type: string
           type: object
+#      type: object # This line causes the CRD to stop working on openshift (last checked on 3.11.154)
+                    # The reason for that is the v1beta1 CRD api changed upstread and the tool
+                    # which generates this file `operator-sdk` uses the upstream api.
+                    # see issue https://github.com/jetstack/cert-manager/issues/2200
   version: v1alpha1
   versions:
   - name: v1alpha1


### PR DESCRIPTION
REDEPLOYED AFTER #79, #81, #83, #85 

follow manual in https://sdk.operatorframework.io/docs/migration/version-upgrade-guide/

* fix(crd): fix crd generation issue
 - due to an upgrade of CRD v1beta1 api, needed to remove a line from the generation
* refactor(k8sclient): seperate classes into different files
* refactor(mockgen): change to filename in mockgen

* feat(Makefile): add target 'make updatevendor'
* fix(projectclaimadapter): correlate struct to interface
* fix(go.mod): add go-autorest version
* refactor(go.mod): reorder dependencies
  - now the go.mod is seperated via:
    > pinned version
    > copied from other commands
    > normal dependencies
* feat(hack): add script to create resources
* fix(projectreference_types): add omitempty to status
  - this caused the crd generation to make status required
  - having the status required broke our operator

How to Upgrade:
---------------

use operator-sdk print-deps
to show what the go.mod should look like

operator-sdk generate k8s --verbose
operator-sdk generate crd --crd-version=v1beta1
chore(openapi): upgrade openapi

to upgrade the steps that were taken:
- take the code from https://sdk.operatorframework.io/docs/migration/version-upgrade-guide/#v017x
- change the input of -h to be `-h <(echo)` or input an empty file
- generate with the commands specified

1. Add the line from https://raw.githubusercontent.com/operator-framework/operator-sdk-samples/c76ff2d5ae03528eb229b9382dce410a8b323ed9/go/memcached-operator/go.mod
2. run `go vet ./{pkg,cmd}/...`
3. run `go mod tidy`
4. run `make`

(cherry picked from commit 6996cfbe37b4491c6ca91e79fc71294de3bd099b)

### What type of PR is this? 
_(bug/feature/cleanup/docs/design/test/chore/refactor..)_

### What this PR does / why we need it:

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [x] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage