### PR TITLE
Changing base image for Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/golang:latest AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 ENV OPERATOR_PATH=/gcp-project-operator
 COPY . ${OPERATOR_PATH}
 WORKDIR ${OPERATOR_PATH}
 RUN make gobuild
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ENV OPERATOR_PATH=/gcp-project-operator \
     OPERATOR_BIN=gcp-project-operator
 


### PR DESCRIPTION
### What type of PR is this? 
_bug_

### What this PR does / why we need it:
PR is raised to use build base image from Redhat which would be supported and to change the operator base image to ubi8.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

_Complies to #_ https://issues.redhat.com/browse/OSD-2383

### Special notes for your reviewer:
Set Golang version to 1.13 for now and not 1.14. Can change if required.

### Is it a breaking change or backward compatible?
Backward compatible