### PR TITLE
OSD-4792 Fix Catalog img build script

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -23,10 +23,9 @@ git clone \
 REMOVED_VERSIONS=""
 if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
     DEPLOYED_HASH=$(
-        curl -s 'https://gitlab.cee.redhat.com/service/saas-osd-operators/raw/master/gcp-project-operator-services/gcp-project-operator.yaml' | \
-            docker run --rm -i evns/yq -r '.services[]|select(.name="gcp-project-operator").hash'
+        curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-gcp-project-operator.yaml" | \
+            docker run --rm -i evns/yq -r '.resourceTemplates[]|select(.name="gcp-project-operator").targets[]|select(.namespace["$ref"]=="/services/osd-operators/namespaces/gcp-project-operator-production.yml")|.ref'
     )
-
     delete=false
     # Sort based on commit number
     for version in $(ls $BUNDLE_DIR | sort -t . -k 3 -g); do


### PR DESCRIPTION
### What type of PR is this? 
bug

### What this PR does / why we need it:
Updates Catalog Img build script to reference the new app-interface repo, instead of the old saas-osd-operators when getting the latest prod git commit
### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
OSD-4792
