### PR TITLE
remove asia-south1 from permitted regions

### DIFF
--- a/pkg/controller/projectclaim/projectclaimadapter.go
+++ b/pkg/controller/projectclaim/projectclaimadapter.go
@@ -51,7 +51,6 @@ var supportedRegions = map[string]bool{
 
 	// Regions below don't have enough quota configured by default, but our org has sufficient quota
 	"asia-east2":   true,
-	"asia-south1":  true,
 	"europe-west2": true,
 	"us-west2":     true,
 
@@ -66,6 +65,7 @@ var supportedRegions = map[string]bool{
 	// "europe-west6":            true,
 	// "europe-north1":           true,
 	// "asia-northeast2":         true,
+	// "asia-south1":             true,
 }
 
 func NewProjectClaimAdapter(projectClaim *gcpv1alpha1.ProjectClaim, logger logr.Logger, client client.Client, manager condition.Conditions) *ProjectClaimAdapter {


### PR DESCRIPTION
### What type of PR is this? 
bug

### What this PR does / why we need it:
asia-south1 region doesn't have sufficient SSD quota by default

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

_Fixes #_
https://issues.redhat.com/browse/OSD-5035

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage