### PR TITLE
Add Read only console access for CCS projects

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -19,9 +19,10 @@ const (
 
 // OperatorConfigMap store data for the specified configmap
 type OperatorConfigMap struct {
-	BillingAccount   string   `yaml:"billingAccount"`
-	ParentFolderID   string   `yaml:"parentFolderID"`
-	CCSConsoleAccess []string `yaml:"ccsConsoleAccess,omitempty"`
+	BillingAccount           string   `yaml:"billingAccount"`
+	ParentFolderID           string   `yaml:"parentFolderID"`
+	CCSConsoleAccess         []string `yaml:"ccsConsoleAccess,omitempty"`
+	CCSReadOnlyConsoleAccess []string `yaml:"ccsReadOnlyConsoleAccess,omitempty"`
 }
 
 // ValidateOperatorConfigMap checks if OperatorConfigMap filled properly

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -31,14 +31,15 @@ func TestValidateOperatorConfigMap(t *testing.T) {
 
 func TestGetOperatorConfigMap(t *testing.T) {
 	tests := []struct {
-		name                     string
-		localObjects             []runtime.Object
-		expectedParentFolderID   string
-		expectedBillingAccount   string
-		expectedCCSConsoleAccess []string
-		expectedErr              error
-		validateResult           func(*testing.T, string, string)
-		validateErr              func(*testing.T, error, error)
+		name                             string
+		localObjects                     []runtime.Object
+		expectedParentFolderID           string
+		expectedBillingAccount           string
+		expectedCCSConsoleAccess         []string
+		expectedCCSReadOnlyConsoleAccess []string
+		expectedErr                      error
+		validateResult                   func(*testing.T, string, string)
+		validateErr                      func(*testing.T, error, error)
 	}{
 		{
 			name: "Correct parentFolderID and billingAccount exist in configmap",
@@ -146,6 +147,35 @@ func TestGetOperatorConfigMap(t *testing.T) {
 			expectedBillingAccount:   "billing123",
 			expectedCCSConsoleAccess: []string{"foo", "bar"},
 			expectedErr:              nil,
+			validateResult: func(t *testing.T, expected, result string) {
+				assert.Equal(t, expected, result)
+			},
+			validateErr: func(t *testing.T, expected, result error) {
+				assert.Equal(t, expected, result)
+			},
+		},
+		{
+			name: "ccsReadOnlyConsoleAccess configured",
+			localObjects: func() []runtime.Object {
+				sec := &corev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gcp-project-operator",
+						Namespace: "gcp-project-operator",
+					},
+					Data: map[string]string{
+						OperatorConfigMapKey: `{parentFolderID: 1234567,billingAccount: "billing123",ccsReadOnlyConsoleAccess: [foo, bar]}`,
+					},
+				}
+				return []runtime.Object{sec}
+			}(),
+			expectedParentFolderID:           "1234567",
+			expectedBillingAccount:           "billing123",
+			expectedCCSReadOnlyConsoleAccess: []string{"foo", "bar"},
+			expectedErr:                      nil,
 			validateResult: func(t *testing.T, expected, result string) {
 				assert.Equal(t, expected, result)
 			},

--- a/pkg/controller/projectreference/projectreference_adapter.go
+++ b/pkg/controller/projectreference/projectreference_adapter.go
@@ -79,6 +79,12 @@ var OSDSREConsoleAccessRoles = []string{
 	"roles/orgpolicy.policyViewer",
 }
 
+// OSDReadOnlyConsoleAccessRoles is a list of Roles that a service account
+// required to get read only console access.
+var OSDReadOnlyConsoleAccessRoles = []string{
+	"roles/viewer",
+}
+
 //ReferenceAdapter is used to do all the processing of the ProjectReference type inside the reconcile loop
 type ReferenceAdapter struct {
 	ProjectClaim     *gcpv1alpha1.ProjectClaim
@@ -251,6 +257,12 @@ func EnsureProjectConfigured(r *ReferenceAdapter) (gcputil.OperationResult, erro
 			// TODO(yeya24): Use google API to check whether this email is
 			// for a group or a service account.
 			if err := r.SetIAMPolicy(email, OSDSREConsoleAccessRoles, gcputil.GoogleGroup); err != nil {
+				return result, err
+			}
+		}
+
+		for _, email := range r.OperatorConfig.CCSReadOnlyConsoleAccess {
+			if err := r.SetIAMPolicy(email, OSDReadOnlyConsoleAccessRoles, gcputil.GoogleGroup); err != nil {
 				return result, err
 			}
 		}

--- a/pkg/controller/projectreference/projectreference_adapter_test.go
+++ b/pkg/controller/projectreference/projectreference_adapter_test.go
@@ -604,6 +604,57 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 				})
 			})
 		})
+
+		Context("When ccsReadOnlyConsoleAccess configured", func() {
+			JustBeforeEach(func() {
+				mockGCPClient.EXPECT().ListAPIs(gomock.Any()).Return(OSDRequiredAPIS, nil)
+				mockGCPClient.EXPECT().GetServiceAccount(gomock.Any()).Return(&iam.ServiceAccount{Email: "foo"}, nil)
+				mockGCPClient.EXPECT().GetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil)
+				mockGCPClient.EXPECT().SetIamPolicy(gomock.Any()).Return(nil, nil)
+				mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeError)
+				mockGCPClient.EXPECT().GetServiceAccount(gomock.Any()).Return(&iam.ServiceAccount{Email: "foo"}, nil)
+				mockGCPClient.EXPECT().CreateServiceAccountKey(gomock.Any()).Return(&iam.ServiceAccountKey{PrivateKeyData: "YWRtaW4="}, nil)
+				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+
+				adapter.OperatorConfig.CCSReadOnlyConsoleAccess = []string{"example-group@xxx.com"}
+			})
+
+			Context("When it is a non CCS project", func() {
+				It("nothing to do", func() {
+					_, err := EnsureProjectConfigured(adapter)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("When it is a CCS project", func() {
+				JustBeforeEach(func() {
+					projectReference.Spec.CCS = true
+				})
+
+				Context("When only one ccsReadOnlyConsoleAccessAccount are configured", func() {
+					It("It doesn't need to create a service account", func() {
+						mockGCPClient.EXPECT().GetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil)
+						mockGCPClient.EXPECT().SetIamPolicy(gomock.Any())
+						_, err := EnsureProjectConfigured(adapter)
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+
+				Context("When multiple ccsReadOnlyConsoleAccessAccount are configured", func() {
+					JustBeforeEach(func() {
+						adapter.OperatorConfig.CCSReadOnlyConsoleAccess = []string{"foo", "bar"}
+					})
+					It("repeat the process", func() {
+						mockGCPClient.EXPECT().GetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil)
+						mockGCPClient.EXPECT().SetIamPolicy(gomock.Any())
+						mockGCPClient.EXPECT().GetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil)
+						mockGCPClient.EXPECT().SetIamPolicy(gomock.Any())
+						_, err := EnsureProjectConfigured(adapter)
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
 	})
 
 	Context("IsDeletionRequested", func() {


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

### What type of PR is this? 
feature

### What this PR does / why we need it:

Add support for read only console access for CCS projects.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

Fixes https://issues.redhat.com/browse/OSD-5044

### Special notes for your reviewer:

Role `roles/resourcemanager.organizationViewer` is also needed for opening a support case, but we have an issue creating it as well in the previous pr https://github.com/openshift/gcp-project-operator/pull/103. @sam-nguyen7 

### Is it a breaking change or backward compatible?

Backward compatible. The new config would be

``` yaml
apiVersion: v1
data:
  config.yaml: |
    billingAccount: "xxx"
    parentFolderID: "xxx"
    ccsConsoleAccess:
    - email-for-sre
    ccsReadOnlyConsoleAccess:
    - email-for-CEE
kind: ConfigMap
metadata:
  name: gcp-project-operator
  namespace: gcp-project-operator
```

### Pre-checks:
- [x] manually tested latest changes against crc/k8s
- [x] run the `make coverage` command to generate new calculated coverage