### PR TITLE
Add roleAdmin role for SRE access

### DIFF
--- a/pkg/controller/projectreference/projectreference_adapter.go
+++ b/pkg/controller/projectreference/projectreference_adapter.go
@@ -77,6 +77,7 @@ var OSDSREConsoleAccessRoles = []string{
 	"roles/iam.serviceAccountAdmin",
 	"roles/serviceusage.serviceUsageAdmin",
 	"roles/orgpolicy.policyViewer",
+	"roles/iam.roleAdmin",
 }
 
 // OSDReadOnlyConsoleAccessRoles is a list of Roles that a service account


### PR DESCRIPTION
### What type of PR is this? 
_(bug/feature/cleanup/docs/design/test/chore/refactor..)_
feature
### What this PR does / why we need it:

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
[OSD-5570](https://issues.redhat.com/browse/OSD-5570)
Since we can't grant roles/iam.organizationRoleAdmin because it is out of scope, roles/iam.roleAdmin is actually all we would need.
_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [x] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage