### PR TITLE
OSD-5570: Add last IAM role for support cases

### DIFF
--- a/pkg/controller/projectreference/projectreference_adapter.go
+++ b/pkg/controller/projectreference/projectreference_adapter.go
@@ -78,6 +78,7 @@ var OSDSREConsoleAccessRoles = []string{
 	"roles/serviceusage.serviceUsageAdmin",
 	"roles/orgpolicy.policyViewer",
 	"roles/iam.roleAdmin",
+	"roles/cloudsupport.techSupportEditor",
 }
 
 // OSDReadOnlyConsoleAccessRoles is a list of Roles that a service account


### PR DESCRIPTION
Add support case IAM role needed

### What type of PR is this? 
feature

### What this PR does / why we need it:

Adds `roles/cloudsupport.techSupportEditor` role so that SREP may open support cases on behalf of the customer.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

[OSD-5570](https://issues.redhat.com/browse/OSD-5570)

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage