### PR TITLE
update apiVersion for OperatorGroup

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -22,7 +22,7 @@ objects:
     displayName: gcp-project-operator Registry
     publisher: SRE 
 
-- apiVersion: operators.coreos.com/v1alpha2
+- apiVersion: operators.coreos.com/v1
   kind: OperatorGroup
   metadata:
     name: gcp-project-operator-og


### PR DESCRIPTION
This PR updates the apiVersion for OperatorGroup to `operators.coreos.com/v1`.