### PR TITLE
Remove orpolicy.policyViewer role

### DIFF
--- a/pkg/controller/projectreference/projectreference_adapter.go
+++ b/pkg/controller/projectreference/projectreference_adapter.go
@@ -76,7 +76,6 @@ var OSDSREConsoleAccessRoles = []string{
 	"roles/servicemanagement.quotaAdmin",
 	"roles/iam.serviceAccountAdmin",
 	"roles/serviceusage.serviceUsageAdmin",
-	"roles/orgpolicy.policyViewer",
 	"roles/iam.roleAdmin",
 	"roles/cloudsupport.techSupportEditor",
 }


### PR DESCRIPTION
### What type of PR is this? 
_(bug/feature/cleanup/docs/design/test/chore/refactor..)_
cleanup
### What this PR does / why we need it:
Removes the roles/orgpolicy.policyViewer from SRE console access group
### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage