### PR TITLE
chore(registry): bump version to latest (4.9) [OSD-6830]

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -95,7 +95,7 @@ REGISTRY_IMG="quay.io/app-sre/gcp-project-operator-registry"
 DOCKERFILE_REGISTRY="Dockerfile.olm-registry"
 
 cat <<EOF > $DOCKERFILE_REGISTRY
-FROM quay.io/openshift/origin-operator-registry:4.5
+FROM quay.io/openshift/origin-operator-registry:4.9
 
 COPY $SAAS_OPERATOR_DIR manifests
 RUN initializer --permissive


### PR DESCRIPTION
- as quay reported an issue with the 4.5 version, 4.9 is the latest
  replacement
