### PR TITLE
OSD-6851: Pull operator image by digest

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -8,6 +8,7 @@ CURRENT_DIR=$(dirname "$0")
 
 BASE_IMG="gcp-project-operator"
 QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
+# FIXME: Don't override this. The default (set in standard.mk) is fine.
 IMG="${BASE_IMG}:latest"
 
 GIT_HASH=$(git rev-parse --short=7 HEAD)

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -12,6 +12,14 @@ QUAY_IMAGE="$2"
 GIT_HASH=$(git rev-parse --short=7 HEAD)
 GIT_COMMIT_COUNT=$(git rev-list $(git rev-list --max-parents=0 HEAD)..HEAD --count)
 
+# Get the repo URI + image digest
+IMAGE_DIGEST=$(skopeo inspect docker://${QUAY_IMAGE}:${GIT_HASH} | jq -r .Digest)
+if [[ -z "$IMAGE_DIGEST" ]]; then
+    echo "Couldn't discover IMAGE_DIGEST for docker://${QUAY_IMAGE}:${GIT_HASH}!"
+    exit 1
+fi
+REPO_DIGEST=${QUAY_IMAGE}@${IMAGE_DIGEST}
+
 # clone bundle repo
 SAAS_OPERATOR_DIR="saas-gcp-project-operator-bundle"
 BUNDLE_DIR="$SAAS_OPERATOR_DIR/gcp-project-operator/"
@@ -58,7 +66,7 @@ PREV_VERSION=$(ls "$BUNDLE_DIR" | sort -t . -k 3 -g | tail -n 1)
     "$PREV_VERSION" \
     "$GIT_COMMIT_COUNT" \
     "$GIT_HASH" \
-    "$QUAY_IMAGE:$GIT_HASH"
+    "$REPO_DIGEST"
 
 NEW_VERSION=$(ls "$BUNDLE_DIR" | sort -t . -k 3 -g | tail -n 1)
 


### PR DESCRIPTION
...rather than by tag.

### What type of PR is this? 
feature

### What this PR does / why we need it:
ICSP policy requires pulling by digest. This sets us up to be able to use ICSP if needed.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
[OSD-6851](https://issues.redhat.com/browse/OSD-6851)

### Is it a breaking change or backward compatible?
Backward compatible. No functional change.

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage