### PR TITLE
Store service account name in ProjectClaim as well

### DIFF
--- a/deploy/crds/gcp.managed.openshift.io_projectclaims_crd.yaml
+++ b/deploy/crds/gcp.managed.openshift.io_projectclaims_crd.yaml
@@ -96,6 +96,8 @@ spec:
               type: object
             region:
               type: string
+            serviceAccountName:
+              type: string
           required:
             - gcpCredentialSecret
             - legalEntity

--- a/pkg/apis/gcp/v1alpha1/projectclaim_types.go
+++ b/pkg/apis/gcp/v1alpha1/projectclaim_types.go
@@ -16,6 +16,7 @@ type ProjectClaimSpec struct {
 	CCS                    bool           `json:"ccs,omitempty"`
 	CCSSecretRef           NamespacedName `json:"ccsSecretRef,omitempty"`
 	CCSProjectID           string         `json:"ccsProjectID,omitempty"`
+	ServiceAccountName     string         `json:"serviceAccountName,omitempty"`
 }
 
 // ProjectClaimStatus defines the observed state of ProjectClaim

--- a/pkg/apis/gcp/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.openapi.go
@@ -130,6 +130,12 @@ func schema_pkg_apis_gcp_v1alpha1_ProjectClaimSpec(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
+					"serviceAccountName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"legalEntity", "gcpCredentialSecret", "region"},
 			},

--- a/pkg/controller/projectreference/projectreference_controller_test.go
+++ b/pkg/controller/projectreference/projectreference_controller_test.go
@@ -145,10 +145,13 @@ parentFolderID: fake-folder
 			)
 		})
 
-		Context("When Reference State is Ready and Project Claim is Ready", func() {
+		Context("When Reference State is Ready Project Claim is Ready and all parameters are set", func() {
 			BeforeEach(func() {
 				projectReference.Status.State = api.ProjectReferenceStatusReady
 				projectClaim.Status.State = api.ClaimStatusReady
+				projectClaim.Spec.GCPProjectID = "fake-project-id"
+				projectClaim.Spec.ServiceAccountName = "fake-service-account"
+				projectClaim.Spec.AvailabilityZones = []string{"zone1", "zone2", "zone3"}
 			})
 
 			It("Does not reconcile", func() {
@@ -217,10 +220,11 @@ parentFolderID: fake-folder
 			})
 		})
 
-		Context("When Reference State is Ready and it fails to update", func() {
+		Context("When Reference State is Ready and it fails to update the ProjectClaim", func() {
 			BeforeEach(func() {
 				projectReference.Status.State = api.ProjectReferenceStatusReady
 				projectClaim.Spec.GCPProjectID = "fake-id"
+				projectClaim.Spec.ServiceAccountName = "fake-service-account"
 				projectClaim.Spec.AvailabilityZones = []string{"zone1", "zone2", "zone3"}
 			})
 


### PR DESCRIPTION
The service account name is the only value that is not replicated in the ProjectClaim

jira: https://issues.redhat.com/browse/OSD-6970