### PR TITLE
Fix return code validation

### DIFF
--- a/pkg/controller/projectreference/projectreference_adapter_test.go
+++ b/pkg/controller/projectreference/projectreference_adapter_test.go
@@ -568,8 +568,6 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 		Context("When it create credentials successfully", func() {
 			Context("Credential Secret already exists", func() {
 				It("Continue execute", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
-					mockGCPClient.EXPECT().CreateProjectLabels(gomock.Any(), gomock.Any()).Return(nil)
 					mockGCPClient.EXPECT().ListAPIs(gomock.Any()).Return(OSDRequiredAPIS, nil)
 					mockGCPClient.EXPECT().GetServiceAccount(gomock.Any()).Return(&iam.ServiceAccount{Email: "foo"}, nil)
 					mockGCPClient.EXPECT().GetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil)
@@ -582,8 +580,6 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 
 			Context("Create a secret successfully", func() {
 				It("Continue execute", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
-					mockGCPClient.EXPECT().CreateProjectLabels(gomock.Any(), gomock.Any()).Return(nil)
 					mockGCPClient.EXPECT().ListAPIs(gomock.Any()).Return(OSDRequiredAPIS, nil)
 					mockGCPClient.EXPECT().GetServiceAccount(gomock.Any()).Return(&iam.ServiceAccount{Email: "foo"}, nil)
 					mockGCPClient.EXPECT().GetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil)
@@ -614,8 +610,6 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 
 			Context("When it is a non CCS project", func() {
 				It("nothing to do", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
-					mockGCPClient.EXPECT().CreateProjectLabels(gomock.Any(), gomock.Any()).Return(nil)
 					_, err := EnsureProjectConfigured(adapter)
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -667,8 +661,6 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 
 			Context("When it is a non CCS project", func() {
 				It("nothing to do", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
-					mockGCPClient.EXPECT().CreateProjectLabels(gomock.Any(), gomock.Any()).Return(nil)
 					_, err := EnsureProjectConfigured(adapter)
 					Expect(err).ToNot(HaveOccurred())
 				})

--- a/pkg/controller/projectreference/projectreference_controller_test.go
+++ b/pkg/controller/projectreference/projectreference_controller_test.go
@@ -403,8 +403,6 @@ parentFolderID: fake-folder
 
 			Context("When the failing to update Status to Ready", func() {
 				It("It requeues with error", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
-					mockGCPClient.EXPECT().CreateProjectLabels(gomock.Any(), gomock.Any()).Return(nil)
 					mockGCPClient.EXPECT().ListProjects().Return([]*cloudresourcemanager.Project{{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}}, nil)
 					mockGCPClient.EXPECT().ListAPIs(gomock.Any())
 					mockGCPClient.EXPECT().EnableAPI(gomock.Any(), gomock.Any()).AnyTimes()
@@ -432,8 +430,6 @@ parentFolderID: fake-folder
 
 			Context("When processes the project reference correctly", func() {
 				It("It does not requeue", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
-					mockGCPClient.EXPECT().CreateProjectLabels(gomock.Any(), gomock.Any()).Return(nil)
 					mockGCPClient.EXPECT().ListProjects().Return([]*cloudresourcemanager.Project{{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}}, nil)
 					mockGCPClient.EXPECT().ListAPIs(gomock.Any())
 					mockGCPClient.EXPECT().EnableAPI(gomock.Any(), gomock.Any()).AnyTimes()


### PR DESCRIPTION
* Project labels don't need to be configured after creating a project
* Return code of service account configuration was ignored, resulting in
  ProjectReference and ProjectClaim being set to ready before creating
  the credentials secret

Co-authored-by: Rafael Azevedo <mail@rafaelazevedo.me>