### PR TITLE
OSD-7174 - Add fake project claim

### DIFF
--- a/pkg/controller/projectclaim/projectclaim_controller.go
+++ b/pkg/controller/projectclaim/projectclaim_controller.go
@@ -23,7 +23,7 @@ var log = logf.Log.WithName("controller_projectclaim")
 
 //go:generate mockgen -destination=../../util/mocks/$GOPACKAGE/customeresourceadapter.go -package=$GOPACKAGE github.com/openshift/gcp-project-operator/pkg/controller/projectclaim CustomResourceAdapter
 type CustomResourceAdapter interface {
-	IsProjectClaimFake() (gcputil.OperationResult, error)
+	EnsureProjectClaimFakeProcessed() (gcputil.OperationResult, error)
 	EnsureProjectClaimDeletionProcessed() (gcputil.OperationResult, error)
 	ProjectReferenceExists() (bool, error)
 	EnsureProjectClaimInitialized() (gcputil.OperationResult, error)
@@ -115,7 +115,7 @@ type ReconcileOperation func() (util.OperationResult, error)
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileProjectClaim) ReconcileHandler(adapter CustomResourceAdapter) (reconcile.Result, error) {
 	operations := []ReconcileOperation{
-		adapter.IsProjectClaimFake,
+		adapter.EnsureProjectClaimFakeProcessed,
 		adapter.EnsureProjectClaimDeletionProcessed,
 		adapter.EnsureProjectClaimInitialized,
 		adapter.EnsureRegionSupported,

--- a/pkg/controller/projectclaim/projectclaim_controller.go
+++ b/pkg/controller/projectclaim/projectclaim_controller.go
@@ -23,6 +23,7 @@ var log = logf.Log.WithName("controller_projectclaim")
 
 //go:generate mockgen -destination=../../util/mocks/$GOPACKAGE/customeresourceadapter.go -package=$GOPACKAGE github.com/openshift/gcp-project-operator/pkg/controller/projectclaim CustomResourceAdapter
 type CustomResourceAdapter interface {
+	IsProjectClaimFake() (gcputil.OperationResult, error)
 	EnsureProjectClaimDeletionProcessed() (gcputil.OperationResult, error)
 	ProjectReferenceExists() (bool, error)
 	EnsureProjectClaimInitialized() (gcputil.OperationResult, error)
@@ -114,6 +115,7 @@ type ReconcileOperation func() (util.OperationResult, error)
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileProjectClaim) ReconcileHandler(adapter CustomResourceAdapter) (reconcile.Result, error) {
 	operations := []ReconcileOperation{
+		adapter.IsProjectClaimFake,
 		adapter.EnsureProjectClaimDeletionProcessed,
 		adapter.EnsureProjectClaimInitialized,
 		adapter.EnsureRegionSupported,

--- a/pkg/controller/projectclaim/projectclaim_controller_test.go
+++ b/pkg/controller/projectclaim/projectclaim_controller_test.go
@@ -75,7 +75,7 @@ var _ = Describe("ProjectclaimController", func() {
 		Context("When the ProjectClaim is newly created", func() {
 			Context("When the ProjectClaim is fake", func() {
 				It("Creates a Fake Secret, updates ProjectClaim with fake specs, sets status to Ready, and does not requeue", func() {
-					mockAdapter.EXPECT().IsProjectClaimFake().Return(gcputil.StopProcessing())
+					mockAdapter.EXPECT().EnsureProjectClaimFakeProcessed().Return(gcputil.StopProcessing())
 					res, err := reconciler.ReconcileHandler(mockAdapter)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(res.Requeue).To(Equal(false))
@@ -84,7 +84,7 @@ var _ = Describe("ProjectclaimController", func() {
 			})
 			Context("When the ProjectClaim is not fake", func() {
 				BeforeEach(func() {
-					mockAdapter.EXPECT().IsProjectClaimFake().Return(gcputil.ContinueProcessing())
+					mockAdapter.EXPECT().EnsureProjectClaimFakeProcessed().Return(gcputil.ContinueProcessing())
 					mockAdapter.EXPECT().EnsureProjectClaimDeletionProcessed().Return(gcputil.ContinueProcessing())
 					mockAdapter.EXPECT().EnsureRegionSupported().Return(gcputil.ContinueProcessing())
 					mockAdapter.EXPECT().EnsureProjectReferenceExists().Return(gcputil.ContinueProcessing())
@@ -154,14 +154,14 @@ var _ = Describe("ProjectclaimController", func() {
 		Context("When the ProjectClaim gets deleted", func() {
 			Context("When the ProjectClaim is fake", func() {
 				It("finalizes the projectclaim", func() {
-					mockAdapter.EXPECT().IsProjectClaimFake().Return(gcputil.StopProcessing())
+					mockAdapter.EXPECT().EnsureProjectClaimFakeProcessed().Return(gcputil.StopProcessing())
 					_, err := reconciler.ReconcileHandler(mockAdapter)
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 			Context("When the ProjectClaim is not fake", func() {
 				It("finalizes the projectclaim", func() {
-					mockAdapter.EXPECT().IsProjectClaimFake().Return(gcputil.ContinueProcessing())
+					mockAdapter.EXPECT().EnsureProjectClaimFakeProcessed().Return(gcputil.ContinueProcessing())
 					mockAdapter.EXPECT().EnsureProjectClaimDeletionProcessed().Return(gcputil.StopProcessing())
 					_, err := reconciler.ReconcileHandler(mockAdapter)
 					Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/projectclaim/projectclaimadapter_test.go
+++ b/pkg/controller/projectclaim/projectclaimadapter_test.go
@@ -341,10 +341,13 @@ disabledRegions:
 		Context("when fake secret doesn't exist", func() {
 			BeforeEach(func() {
 				notFound := errors.NewNotFound(schema.GroupResource{}, "FakeSecret")
-				matcher := testStructs.NewSecretMatcher()
+				secretMatcher := testStructs.NewSecretMatcher()
 				mockClient.EXPECT().Update(gomock.Any(), projectClaim).Times(2)
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(notFound)
-				mockClient.EXPECT().Create(gomock.Any(), matcher)
+				mockClient.EXPECT().Create(gomock.Any(), secretMatcher)
+				claimMatcher := testStructs.NewProjectClaimMatcher()
+				mockClient.EXPECT().Status().Return(mockStatusWriter)
+				mockStatusWriter.EXPECT().Update(gomock.Any(), claimMatcher)
 			})
 			It("creates fake secret", func() {
 				_, err := adapter.IsProjectClaimFake()
@@ -355,8 +358,11 @@ disabledRegions:
 		Context("when ProjectClaim GCPProjectID is not fake", func() {
 			BeforeEach(func() {
 				projectClaim.Spec.GCPProjectID = ""
+				matcher := testStructs.NewProjectClaimMatcher()
 				mockClient.EXPECT().Update(gomock.Any(), projectClaim)
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, GCPCredentialSecret)
+				mockClient.EXPECT().Status().Return(mockStatusWriter)
+				mockStatusWriter.EXPECT().Update(gomock.Any(), matcher)
 			})
 			It("updates ProjectClaim with fake specs", func() {
 				matcher := testStructs.NewProjectClaimMatcher()

--- a/pkg/controller/projectclaim/projectclaimadapter_test.go
+++ b/pkg/controller/projectclaim/projectclaimadapter_test.go
@@ -332,7 +332,7 @@ disabledRegions:
 				mockClient.EXPECT().Delete(gomock.Any(), &testStructs.ProjectReferenceMatcher{})
 			})
 			It("removes fake secret", func() {
-				result, err := adapter.IsProjectClaimFake()
+				result, err := adapter.EnsureProjectClaimFakeProcessed()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.CancelRequest).To(Equal(true))
 			})
@@ -347,7 +347,7 @@ disabledRegions:
 				mockClient.EXPECT().Create(gomock.Any(), matcher)
 			})
 			It("creates fake secret", func() {
-				_, err := adapter.IsProjectClaimFake()
+				_, err := adapter.EnsureProjectClaimFakeProcessed()
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -362,7 +362,7 @@ disabledRegions:
 			It("updates ProjectClaim with fake specs", func() {
 				matcher := testStructs.NewProjectClaimMatcher()
 				mockClient.EXPECT().Update(gomock.Any(), matcher).Times(1)
-				result, err := adapter.IsProjectClaimFake()
+				result, err := adapter.EnsureProjectClaimFakeProcessed()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.CancelRequest).To(Equal(true))
 				Expect(matcher.ActualProjectClaim.Spec.GCPProjectID).To(Equal("fakeProjectClaim"))
@@ -388,7 +388,7 @@ disabledRegions:
 				matcher := testStructs.NewProjectClaimMatcher()
 				mockClient.EXPECT().Status().Return(mockStatusWriter)
 				mockStatusWriter.EXPECT().Update(gomock.Any(), matcher)
-				result, err := adapter.IsProjectClaimFake()
+				result, err := adapter.EnsureProjectClaimFakeProcessed()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.CancelRequest).To(Equal(true))
 				Expect(matcher.ActualProjectClaim.Status.State).To(Equal(gcpv1alpha1.ClaimStatusReady))
@@ -403,7 +403,7 @@ disabledRegions:
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, GCPCredentialSecret)
 			})
 			It("doesn't change the ProjectClaim", func() {
-				result, err := adapter.IsProjectClaimFake()
+				result, err := adapter.EnsureProjectClaimFakeProcessed()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.CancelRequest).To(Equal(true))
 			})

--- a/pkg/controller/projectclaim/projectclaimadapter_test.go
+++ b/pkg/controller/projectclaim/projectclaimadapter_test.go
@@ -341,13 +341,10 @@ disabledRegions:
 		Context("when fake secret doesn't exist", func() {
 			BeforeEach(func() {
 				notFound := errors.NewNotFound(schema.GroupResource{}, "FakeSecret")
-				secretMatcher := testStructs.NewSecretMatcher()
+				matcher := testStructs.NewSecretMatcher()
 				mockClient.EXPECT().Update(gomock.Any(), projectClaim).Times(2)
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(notFound)
-				mockClient.EXPECT().Create(gomock.Any(), secretMatcher)
-				claimMatcher := testStructs.NewProjectClaimMatcher()
-				mockClient.EXPECT().Status().Return(mockStatusWriter)
-				mockStatusWriter.EXPECT().Update(gomock.Any(), claimMatcher)
+				mockClient.EXPECT().Create(gomock.Any(), matcher)
 			})
 			It("creates fake secret", func() {
 				_, err := adapter.IsProjectClaimFake()
@@ -358,11 +355,9 @@ disabledRegions:
 		Context("when ProjectClaim GCPProjectID is not fake", func() {
 			BeforeEach(func() {
 				projectClaim.Spec.GCPProjectID = ""
-				matcher := testStructs.NewProjectClaimMatcher()
 				mockClient.EXPECT().Update(gomock.Any(), projectClaim)
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, GCPCredentialSecret)
-				mockClient.EXPECT().Status().Return(mockStatusWriter)
-				mockStatusWriter.EXPECT().Update(gomock.Any(), matcher)
+
 			})
 			It("updates ProjectClaim with fake specs", func() {
 				matcher := testStructs.NewProjectClaimMatcher()

--- a/pkg/util/mocks/projectclaim/customeresourceadapter.go
+++ b/pkg/util/mocks/projectclaim/customeresourceadapter.go
@@ -185,6 +185,21 @@ func (mr *MockCustomResourceAdapterMockRecorder) FinalizeProjectClaim() *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeProjectClaim", reflect.TypeOf((*MockCustomResourceAdapter)(nil).FinalizeProjectClaim))
 }
 
+// IsProjectClaimFake mocks base method
+func (m *MockCustomResourceAdapter) IsProjectClaimFake() (util.OperationResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsProjectClaimFake")
+	ret0, _ := ret[0].(util.OperationResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsProjectClaimFake indicates an expected call of IsProjectClaimFake
+func (mr *MockCustomResourceAdapterMockRecorder) IsProjectClaimFake() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsProjectClaimFake", reflect.TypeOf((*MockCustomResourceAdapter)(nil).IsProjectClaimFake))
+}
+
 // ProjectReferenceExists mocks base method
 func (m *MockCustomResourceAdapter) ProjectReferenceExists() (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/util/mocks/projectclaim/customeresourceadapter.go
+++ b/pkg/util/mocks/projectclaim/customeresourceadapter.go
@@ -80,6 +80,21 @@ func (mr *MockCustomResourceAdapterMockRecorder) EnsureProjectClaimDeletionProce
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureProjectClaimDeletionProcessed", reflect.TypeOf((*MockCustomResourceAdapter)(nil).EnsureProjectClaimDeletionProcessed))
 }
 
+// EnsureProjectClaimFakeProcessed mocks base method
+func (m *MockCustomResourceAdapter) EnsureProjectClaimFakeProcessed() (util.OperationResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureProjectClaimFakeProcessed")
+	ret0, _ := ret[0].(util.OperationResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnsureProjectClaimFakeProcessed indicates an expected call of EnsureProjectClaimFakeProcessed
+func (mr *MockCustomResourceAdapterMockRecorder) EnsureProjectClaimFakeProcessed() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureProjectClaimFakeProcessed", reflect.TypeOf((*MockCustomResourceAdapter)(nil).EnsureProjectClaimFakeProcessed))
+}
+
 // EnsureProjectClaimInitialized mocks base method
 func (m *MockCustomResourceAdapter) EnsureProjectClaimInitialized() (util.OperationResult, error) {
 	m.ctrl.T.Helper()
@@ -183,21 +198,6 @@ func (m *MockCustomResourceAdapter) FinalizeProjectClaim() (projectclaim.ObjectS
 func (mr *MockCustomResourceAdapterMockRecorder) FinalizeProjectClaim() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeProjectClaim", reflect.TypeOf((*MockCustomResourceAdapter)(nil).FinalizeProjectClaim))
-}
-
-// EnsureProjectClaimFakeProcessed mocks base method
-func (m *MockCustomResourceAdapter) EnsureProjectClaimFakeProcessed() (util.OperationResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureProjectClaimFakeProcessed")
-	ret0, _ := ret[0].(util.OperationResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// EnsureProjectClaimFakeProcessed indicates an expected call of EnsureProjectClaimFakeProcessed
-func (mr *MockCustomResourceAdapterMockRecorder) EnsureProjectClaimFakeProcessed() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureProjectClaimFakeProcessed", reflect.TypeOf((*MockCustomResourceAdapter)(nil).EnsureProjectClaimFakeProcessed))
 }
 
 // ProjectReferenceExists mocks base method

--- a/pkg/util/mocks/projectclaim/customeresourceadapter.go
+++ b/pkg/util/mocks/projectclaim/customeresourceadapter.go
@@ -185,19 +185,19 @@ func (mr *MockCustomResourceAdapterMockRecorder) FinalizeProjectClaim() *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeProjectClaim", reflect.TypeOf((*MockCustomResourceAdapter)(nil).FinalizeProjectClaim))
 }
 
-// IsProjectClaimFake mocks base method
-func (m *MockCustomResourceAdapter) IsProjectClaimFake() (util.OperationResult, error) {
+// EnsureProjectClaimFakeProcessed mocks base method
+func (m *MockCustomResourceAdapter) EnsureProjectClaimFakeProcessed() (util.OperationResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsProjectClaimFake")
+	ret := m.ctrl.Call(m, "EnsureProjectClaimFakeProcessed")
 	ret0, _ := ret[0].(util.OperationResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsProjectClaimFake indicates an expected call of IsProjectClaimFake
-func (mr *MockCustomResourceAdapterMockRecorder) IsProjectClaimFake() *gomock.Call {
+// EnsureProjectClaimFakeProcessed indicates an expected call of EnsureProjectClaimFakeProcessed
+func (mr *MockCustomResourceAdapterMockRecorder) EnsureProjectClaimFakeProcessed() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsProjectClaimFake", reflect.TypeOf((*MockCustomResourceAdapter)(nil).IsProjectClaimFake))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureProjectClaimFakeProcessed", reflect.TypeOf((*MockCustomResourceAdapter)(nil).EnsureProjectClaimFakeProcessed))
 }
 
 // ProjectReferenceExists mocks base method


### PR DESCRIPTION
### What type of PR is this? 
feature

### What this PR does / why we need it:
As SDA developer, I want to be able to create a fake project claim that moves into ready instantly, so that I can test integration with GCP Project Operator

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [x] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage