### PR TITLE
OSD-7839 - Remove wildcard from operator role

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -4,64 +4,66 @@ metadata:
   creationTimestamp: null
   name: gcp-project-operator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - gcp-project-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - gcp.managed.openshift.io
-  resources:
-  - projectclaims
-  - projectreferences
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - gcp-project-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - gcp.managed.openshift.io
+    resources:
+      - projectclaims
+      - projectclaims/status
+      - projectreferences
+      - projectreferences/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -55,7 +55,7 @@ rules:
 - apiGroups:
   - gcp.managed.openshift.io
   resources:
-  - '*'
+  - projectclaims
   - projectreferences
   verbs:
   - create


### PR DESCRIPTION
### What type of PR is this? 
bug

### What this PR does / why we need it:
GCP Project Operator uses a wildcard in the gcp.managed.openshift.io group but shouldn't. Removing wildcard from operator role.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

Fixes https://issues.redhat.com/browse/OSD-7839

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [x] manually tested latest changes against crc/k8s
- [x] run the `make coverage` command to generate new calculated coverage