### PR TITLE
OSD-7561 Clean up label creation call on every reconcile

### DIFF
--- a/pkg/controller/projectreference/projectreference_adapter_test.go
+++ b/pkg/controller/projectreference/projectreference_adapter_test.go
@@ -130,8 +130,6 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 				})
 
 				It("returns without altering ProjectClaim", func() {
-					mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
-					mockGCPClient.EXPECT().CreateProjectLabels(gomock.Any(), gomock.Any()).Return(nil)
 					oldClaim := projectClaim.DeepCopy()
 					_, err := EnsureProjectClaimReady(adapter)
 					Expect(err).NotTo(HaveOccurred())
@@ -291,37 +289,6 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 				})
 			})
 		})
-	})
-	Context("ConfigureProjectLabel", func() {
-		var (
-			claimName string
-		)
-		JustBeforeEach(func() {
-			mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE",
-				ProjectId: projectReference.Spec.GCPProjectID, Labels: map[string]string{"claim_name": claimName}}, nil)
-		})
-		Context("When an existing project has the correct label", func() {
-			BeforeEach(func() {
-				claimName = projectClaim.Name
-			})
-			It("Does nothing", func() {
-				result, err := adapter.ConfigureProjectLabel()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(continueProcessingResult))
-			})
-		})
-		Context("When an existing project has a wrong label", func() {
-			BeforeEach(func() {
-				claimName = "fake-wrong-label"
-			})
-			It("Updates the labels on the project", func() {
-				mockGCPClient.EXPECT().CreateProjectLabels(gomock.Any(), map[string]string{"claim_name": projectClaim.Name}).Return(nil)
-				result, err := adapter.ConfigureProjectLabel()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(continueProcessingResult))
-			})
-		})
-
 	})
 
 	Context("EnsureProjectCreated", func() {

--- a/pkg/controller/projectreference/projectreference_controller_test.go
+++ b/pkg/controller/projectreference/projectreference_controller_test.go
@@ -152,8 +152,6 @@ parentFolderID: fake-folder
 			})
 
 			It("Does not reconcile", func() {
-				mockGCPClient.EXPECT().GetProject(gomock.Any()).Return(&cloudresourcemanager.Project{LifecycleState: "ACTIVE", ProjectId: projectReference.Spec.GCPProjectID}, nil)
-				mockGCPClient.EXPECT().CreateProjectLabels(gomock.Any(), gomock.Any()).Return(nil)
 				_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: projectReferenceName})
 				Expect(err).NotTo(HaveOccurred())
 			})


### PR DESCRIPTION
### What type of PR is this? 
cleanup

### What this PR does / why we need it:
Cleans up label creation call on every reconcile

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
[OSD-7561](https://issues.redhat.com/browse/OSD-7561)

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage