### PR TITLE
OSD-8522 project id generation to use sha256

### DIFF
--- a/pkg/controller/projectreference/projectreference_adapter.go
+++ b/pkg/controller/projectreference/projectreference_adapter.go
@@ -2,7 +2,7 @@ package projectreference
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -394,7 +394,7 @@ func (r *ReferenceAdapter) EnsureProjectCleanedUp() error {
 
 func GenerateProjectID() (string, error) {
 	guid := uuid.New().String()
-	hashing := sha1.New()
+	hashing := sha256.New()
 	_, err := hashing.Write([]byte(guid))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
### What type of PR is this? 
chore

### What this PR does / why we need it:
GCP Project Operator uses sha1 sum to generate project IDs. This was detected by gosec as a security vulnerability. While it's not a real risk since collisions are handled and it's just for ID generation, we need to fix the problem so it doesn't pop up in every evaluation.

This PR updates the project ID generation to use sha256 instead.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
https://issues.redhat.com/browse/OSD-8522

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage