### PR TITLE
Add network security API to OSDRequiredAPIS

### DIFF
--- a/pkg/controller/projectreference/projectreference_adapter.go
+++ b/pkg/controller/projectreference/projectreference_adapter.go
@@ -55,6 +55,7 @@ var OSDRequiredAPIS = []string{
 	"cloudapis.googleapis.com",
 	"iamcredentials.googleapis.com",
 	"servicemanagement.googleapis.com",
+	"networksecurity.googleapis.com", // https://bugzilla.redhat.com/show_bug.cgi?id=2021731
 }
 
 // OSDRequiredRoles is a list of Roles that a service account


### PR DESCRIPTION
### What type of PR is this? 
bug

### What this PR does / why we need it:
Add `networksecurity.googleapis.com` to list of APIs to enabled API list in OSD

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
ref [BZ2021731](https://bugzilla.redhat.com/show_bug.cgi?id=2021731)

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage