### PR TITLE
OSD-8920: removed SRE console access of CCS project + refactoring

### DIFF
--- a/pkg/controller/projectclaim/projectclaim_controller.go
+++ b/pkg/controller/projectclaim/projectclaim_controller.go
@@ -1,3 +1,7 @@
+// Package projectclaim contains the logic to reconcile the change of a ProjectClaim CR
+// On the initial creation of a ProjectClaim, the main objective is to create a ProjectReference
+// for the case that the Region is supported. After the attempt of reconciling the ProjectRefrence the
+// ProjectClaim is updated with the result of the procedure.
 package projectclaim
 
 import (

--- a/pkg/controller/projectclaim/projectclaim_fake.go
+++ b/pkg/controller/projectclaim/projectclaim_fake.go
@@ -1,0 +1,118 @@
+package projectclaim
+
+// This file contains the functions for handling a fake ProjectClaim, that doesn't actually allocate resources on GCP
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	gcpv1alpha1 "github.com/openshift/gcp-project-operator/pkg/apis/gcp/v1alpha1"
+	gcputil "github.com/openshift/gcp-project-operator/pkg/util"
+	operrors "github.com/openshift/gcp-project-operator/pkg/util/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (c *ProjectClaimAdapter) CreateFakeSecret() error {
+	if !gcputil.SecretExists(c.client, c.projectClaim.Spec.GCPCredentialSecret.Name, c.projectClaim.Spec.GCPCredentialSecret.Namespace) {
+		privateKeyString, err := base64.StdEncoding.DecodeString("SS1hbS1mYWtlLXBhc3M=")
+		if err != nil {
+			return err
+		}
+		if err := c.client.Create(context.TODO(), gcputil.NewGCPSecretCR(string(privateKeyString), types.NamespacedName{Namespace: c.projectClaim.Spec.GCPCredentialSecret.Namespace, Name: c.projectClaim.Spec.GCPCredentialSecret.Name})); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *ProjectClaimAdapter) DeleteFakeSecret() error {
+	secret := &corev1.Secret{}
+	err := c.client.Get(context.TODO(), types.NamespacedName{
+		Name:      c.projectClaim.Spec.GCPCredentialSecret.Name,
+		Namespace: c.projectClaim.Spec.GCPCredentialSecret.Namespace},
+		secret,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = c.client.Delete(context.TODO(), secret)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *ProjectClaimAdapter) UpdateFakeProjectClaimSpecs() (bool, error) {
+	if c.projectClaim.Spec.GCPProjectID != "fakeProjectClaim" {
+		c.projectClaim.Spec.GCPProjectID = "fakeProjectClaim"
+		c.projectClaim.Spec.GCPCredentialSecret = gcpv1alpha1.NamespacedName{
+			Name:      c.projectClaim.GetName(),
+			Namespace: c.projectClaim.GetNamespace(),
+		}
+		c.projectClaim.Spec.Region = "fakeRegion"
+		c.projectClaim.Spec.AvailabilityZones = []string{
+			"fake-az-a",
+			"fake-az-b",
+			"fake-az-c",
+		}
+		err := c.client.Update(context.TODO(), c.projectClaim)
+		if err != nil {
+			return true, err
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+func (c *ProjectClaimAdapter) UpdateFakeProjectClaimState() (bool, error) {
+	if c.projectClaim.Status.State != gcpv1alpha1.ClaimStatusReady {
+		c.projectClaim.Status.Conditions = []gcpv1alpha1.Condition{}
+		c.projectClaim.Status.State = gcpv1alpha1.ClaimStatusReady
+		err := c.client.Status().Update(context.TODO(), c.projectClaim)
+		if err != nil {
+			return true, err
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+func (c *ProjectClaimAdapter) EnsureProjectClaimFakeProcessed() (gcputil.OperationResult, error) {
+	if c.projectClaim.Annotations[FakeProjectClaim] != "true" {
+		return gcputil.ContinueProcessing()
+	}
+	if _, err := c.EnsureFinalizer(); err != nil {
+		return gcputil.RequeueWithError(operrors.Wrap(err, fmt.Sprintf("Failed to add finalizer for %s", c.projectClaim.Name)))
+	}
+	// If project claim is marked for deletion, remove fake secret and project claim
+	if c.projectClaim.DeletionTimestamp != nil {
+		if err := c.DeleteFakeSecret(); err != nil {
+			return gcputil.RequeueWithError(operrors.Wrap(err, fmt.Sprintf("Could not delete fake secret %s", c.projectClaim.Spec.GCPCredentialSecret.Name)))
+		}
+		if _, err := c.EnsureProjectClaimDeletionProcessed(); err != nil {
+			return gcputil.RequeueWithError(operrors.Wrap(err, fmt.Sprintf("Could not delete project claim %s", c.projectClaim.Name)))
+		}
+		return gcputil.StopProcessing()
+	}
+	if err := c.CreateFakeSecret(); err != nil {
+		return gcputil.RequeueWithError(operrors.Wrap(err, fmt.Sprintf("Could not create fake secret %s", c.projectClaim.Spec.GCPCredentialSecret.Name)))
+	}
+	result, err := c.UpdateFakeProjectClaimSpecs()
+	if err != nil {
+		return gcputil.RequeueWithError(operrors.Wrap(err, fmt.Sprintf("Could not update project claim specs for %s", c.projectClaim.Name)))
+	}
+	if !result {
+		return gcputil.StopProcessing()
+	}
+	result, err = c.UpdateFakeProjectClaimState()
+	if err != nil {
+		return gcputil.RequeueWithError(operrors.Wrap(err, fmt.Sprintf("Could not update project claim specs for %s", c.projectClaim.Name)))
+	}
+	if !result {
+		return gcputil.StopProcessing()
+	}
+	return gcputil.StopProcessing()
+}

--- a/pkg/controller/projectreference/projectreference_adapter_test.go
+++ b/pkg/controller/projectreference/projectreference_adapter_test.go
@@ -723,11 +723,12 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 	Context("EnsureProjectCleanedUp", func() {
 		var (
 			projectState string
+			email        string
 		)
 		BeforeEach(func() {
 			projectReference.Spec.GCPProjectID = "fake-id"
 			projectState = "ACTIVE"
-			email := "Some Email"
+			email = "Some Email"
 			mockGCPClient.EXPECT().GetServiceAccount(gomock.Any()).Return(&iam.ServiceAccount{Email: email}, nil).Times(1)
 			mockGCPClient.EXPECT().DeleteServiceAccount(gomock.Eq(email)).Return(nil).Times(1)
 		})
@@ -793,6 +794,20 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any())
 				err := adapter.EnsureProjectCleanedUp()
 				Expect(err).NotTo(HaveOccurred())
+			})
+			Context("When SRE console access has been configured", func() {
+				JustBeforeEach(func() {
+					adapter.OperatorConfig.CCSConsoleAccess = []string{"foo"}
+					adapter.OperatorConfig.CCSReadOnlyConsoleAccess = []string{"foo"}
+				})
+				It("removes the Policies for that access", func() {
+					mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, corev1.Secret{}).Times(2)
+					mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any())
+					mockGCPClient.EXPECT().GetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil).Times(2)
+					mockGCPClient.EXPECT().SetIamPolicy(gomock.Any()).Times(2)
+					err := adapter.EnsureProjectCleanedUp()
+					Expect(err).NotTo(HaveOccurred())
+				})
 			})
 		})
 	})

--- a/pkg/controller/projectreference/projectreference_controller.go
+++ b/pkg/controller/projectreference/projectreference_controller.go
@@ -159,6 +159,7 @@ func (r *ReconcileProjectReference) ReconcileHandler(adapter *ReferenceAdapter, 
 	return r.doNotRequeue()
 }
 
+// Returns a gcpClient, that uses the access credential Secret in the CCS project namespace or the operator namespace
 func (r *ReconcileProjectReference) getGcpClient(projectReference *gcpv1alpha1.ProjectReference, logger logr.Logger) (gcpclient.Client, error) {
 	credSecretNamespace := operatorNamespace
 	credSecretName := orgGcpSecretName

--- a/pkg/controller/projectreference/projectreference_controller.go
+++ b/pkg/controller/projectreference/projectreference_controller.go
@@ -170,14 +170,14 @@ func (r *ReconcileProjectReference) getGcpClient(projectReference *gcpv1alpha1.P
 	// Get org creds from secret
 	creds, err := util.GetGCPCredentialsFromSecret(r.client, credSecretNamespace, credSecretName)
 	if err != nil {
-		err = operrors.Wrap(err, fmt.Sprintf("could not get org Creds from secret: %s, for namespace %s", orgGcpSecretName, operatorNamespace))
+		err = operrors.Wrap(err, fmt.Sprintf("could not get Creds from secret: %s, for namespace %s", credSecretName, credSecretNamespace))
 		return nil, err
 	}
 
 	// Get gcpclient with creds
 	gcpClient, err := r.gcpClientBuilder(projectReference.Spec.GCPProjectID, creds)
 	if err != nil {
-		return nil, operrors.Wrap(err, fmt.Sprintf("could not get gcp client with secret: %s, for namespace %s", orgGcpSecretName, operatorNamespace))
+		return nil, operrors.Wrap(err, fmt.Sprintf("could not get gcp client with secret: %s, for namespace %s", credSecretName, credSecretNamespace))
 	}
 
 	return gcpClient, nil

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -21,6 +21,8 @@ const (
 	GoogleGroup
 )
 
+var PrefixMemberType = []string{"serviceAccount:", "group:"}
+
 // SecretExists returns a boolean to the caller based on the secretName and namespace args.
 func SecretExists(kubeClient client.Client, secretName, namespace string) bool {
 	s := &corev1.Secret{}
@@ -129,10 +131,7 @@ func AddOrUpdateBinding(existingBindings []*cloudresourcemanager.Binding, requir
 
 // roleBindingMap returns a map of requiredBindings role bindings for the added members
 func rolebindingMap(roles []string, member string, memberType IamMemberType) map[string]cloudresourcemanager.Binding {
-	prefix := "serviceAccount:"
-	if memberType == GoogleGroup {
-		prefix = "group:"
-	}
+	prefix := PrefixMemberType[memberType]
 	requiredBindings := make(map[string]cloudresourcemanager.Binding)
 	for _, role := range roles {
 		requiredBindings[role] = cloudresourcemanager.Binding{


### PR DESCRIPTION
Removes the IAM Policy for SRE console access after a openshift was uninstalled in a CCS project. Moved out fake CR reconciliation logic to an own file