### PR TITLE
Replace Go 1.16 with 1.17 in builder image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,13 @@
 FROM quay.io/app-sre/boilerplate:image-v2.1.0 AS builder
+
+# Replace Go 1.16 with 1.17:
+RUN \
+    rm -rf /usr/local/go && \
+    curl -Lo /tmp/tarball https://go.dev/dl/go1.17.7.linux-amd64.tar.gz && \
+    echo 02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259 /tmp/tarball | sha256sum -c && \
+    tar -C /usr/local -xf /tmp/tarball && \
+    rm /tmp/tarball
+
 ENV OPERATOR_PATH=/gcp-project-operator
 COPY . ${OPERATOR_PATH}
 WORKDIR ${OPERATOR_PATH}


### PR DESCRIPTION
### What type of PR is this? 

Refactor.

### What this PR does / why we need it:

This patch changes the builder image so that it uses Go 1.17. Note that
there are currently no version of the _boilerplate_ base image that
contains Go 1.17, so the approach here is to remove Go 1.16 and install
1.17 explicitly.

Updating to Go 1.17 is necessary because without it it is not possible
to update to the latest versions of the Kubernetes API packages. In
particular the [sigs.k8s.io/json](https://github.com/kubernetes-sigs/json)
package doesn't work with Go 1.16 because it uses the `IsExported`
method that was added in Go 1.17.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

This is a prerequisite for #170, which is a prerequisite for [SDA-5500](https://issues.redhat.com/browse/SDA-5500).

### Special notes for your reviewer:

No special notes.

### Is it a breaking change or backward compatible?

Backward compatible.