### PR TITLE
Enable FIPS by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+FIPS_ENABLED=true
+
 include boilerplate/generated-includes.mk
 
 SHELL := /usr/bin/env bash

--- a/fips.go
+++ b/fips.go
@@ -1,0 +1,15 @@
+// +build fips_enabled
+
+// BOILERPLATE GENERATED -- DO NOT EDIT
+// Run 'make ensure-fips' to regenerate
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+	"fmt"
+)
+
+func init() {
+	fmt.Println("***** Starting with FIPS crypto enabled *****")
+}


### PR DESCRIPTION
### What type of PR is this? 
Feature

### What this PR does / why we need it:
With this PR FIPS is enabled by default making the operator FIPS compliant.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
Resolves: [OSD-11686](https://issues.redhat.com/browse/OSD-11686) 

### Is it a breaking change or backward compatible?
Backwards compatible