### PR TITLE
Removing georgettica from OWNERS -- OHSS-13013

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ reviewers:
 - pyates86
 - rafael-azevedo
 - Tessg22
-- georgettica
 - sam-nguyen7
 - shibumi
 approvers:


### PR DESCRIPTION
### What type of PR is this? 
cleanup

### What this PR does / why we need it:
PR removes georgettica from OWNERS file

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
[OHSS-13013](https://issues.redhat.com//browse/OHSS-13013)

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?
Backward compatible

### Pre-checks:
- [ N/A] manually tested latest changes against crc/k8s
- [ N/A] run the `make coverage` command to generate new calculated coverage