### PR TITLE
OHSS-14525 Removal of leaver shibumi from owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,7 +7,6 @@ reviewers:
 - Tessg22
 - georgettica
 - sam-nguyen7
-- shibumi
 approvers:
 - NautiluX
 - rafael-azevedo


### PR DESCRIPTION
### What type of PR is this? 
_(bug/feature/cleanup/docs/design/test/chore/refactor..)_
cleanup
### What this PR does / why we need it:

Step [12.3.3](https://github.com/openshift/ops-sop/blob/master/security/leaver_process.asciidoc#1233-review-users-owners-permissions) of the leaver process SOP includes removal from our openshift repos. Hence, this PR serves the removal of Christian Rebischke.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

_Fixes #_ [OHSS-14525](https://issues.redhat.com//browse/OHSS-14525)

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage