### PR TITLE
[OSD-15800] Delete IAM policy bindings before deleting Service Account

### DIFF
--- a/controllers/projectreference/projectreference_adapter.go
+++ b/controllers/projectreference/projectreference_adapter.go
@@ -468,9 +468,9 @@ func (r *ReferenceAdapter) deleteServiceAccount() error {
 
 	r.logger.V(1).Info("after get")
 
-    if err := r.DeleteIAMPolicy(sa.Email, 0); err != nil {
+	if err := r.DeleteIAMPolicy(sa.Email, 0); err != nil {
 		return operrors.Wrap(err, "could not delete the IAM policy, something happened")
-    }
+	}
 
 	if err := r.gcpClient.DeleteServiceAccount(sa.Email); err != nil {
 		return operrors.Wrap(err, "could not delete the SA, something happened")

--- a/controllers/projectreference/projectreference_adapter.go
+++ b/controllers/projectreference/projectreference_adapter.go
@@ -465,7 +465,12 @@ func (r *ReferenceAdapter) deleteServiceAccount() error {
 
 		return operrors.Wrap(err, "could not get the SA, something happened")
 	}
+
 	r.logger.V(1).Info("after get")
+
+    if err := r.DeleteIAMPolicy(sa.Email, 0); err != nil {
+		return operrors.Wrap(err, "could not delete the IAM policy, something happened")
+    }
 
 	if err := r.gcpClient.DeleteServiceAccount(sa.Email); err != nil {
 		return operrors.Wrap(err, "could not delete the SA, something happened")

--- a/controllers/projectreference/projectreference_adapter.go
+++ b/controllers/projectreference/projectreference_adapter.go
@@ -468,7 +468,7 @@ func (r *ReferenceAdapter) deleteServiceAccount() error {
 
 	r.logger.V(1).Info("after get")
 
-	if err := r.DeleteIAMPolicy(sa.Email, 0); err != nil {
+	if err := r.DeleteIAMPolicy(sa.Email, util.ServiceAccount); err != nil {
 		return operrors.Wrap(err, "could not delete the IAM policy, something happened")
 	}
 

--- a/controllers/projectreference/projectreference_adapter_test.go
+++ b/controllers/projectreference/projectreference_adapter_test.go
@@ -730,6 +730,8 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 			projectState = "ACTIVE"
 			email = "Some Email"
 			mockGCPClient.EXPECT().GetServiceAccount(gomock.Any()).Return(&iam.ServiceAccount{Email: email}, nil).Times(1)
+            mockGCPClient.EXPECT().GetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil)
+            mockGCPClient.EXPECT().SetIamPolicy(gomock.Any())
 			mockGCPClient.EXPECT().DeleteServiceAccount(gomock.Eq(email)).Return(nil).Times(1)
 		})
 		Context("When it's a non-CCS Project", func() {

--- a/controllers/projectreference/projectreference_adapter_test.go
+++ b/controllers/projectreference/projectreference_adapter_test.go
@@ -730,8 +730,7 @@ var _ = Describe("ProjectreferenceAdapter", func() {
 			projectState = "ACTIVE"
 			email = "Some Email"
 			mockGCPClient.EXPECT().GetServiceAccount(gomock.Any()).Return(&iam.ServiceAccount{Email: email}, nil).Times(1)
-            mockGCPClient.EXPECT().GetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil)
-            mockGCPClient.EXPECT().SetIamPolicy(gomock.Any())
+			mockGCPClient.EXPECT().GetIamPolicy(gomock.Any()).Return(&cloudresourcemanager.Policy{}, nil)
 			mockGCPClient.EXPECT().DeleteServiceAccount(gomock.Eq(email)).Return(nil).Times(1)
 		})
 		Context("When it's a non-CCS Project", func() {


### PR DESCRIPTION
### What type of PR is this? 
Bug fix

### What this PR does / why we need it:

To prevent policy bindings being left behind

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

Fixes [OSD-15800](https://issues.redhat.com/browse/OSD-15800)

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage