### PR TITLE
Make catalogsource compatible with restricted SCC enforcement

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -26,6 +26,8 @@ objects:
     name: gcp-project-operator-catalog
   spec:
     sourceType: grpc
+    grpcPodConfig:
+      securityContextConfig: restricted
     image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
     displayName: gcp-project-operator Registry
     publisher: SRE 


### PR DESCRIPTION
* Restricted SCC enforcement will be added with OCP 4.14
* Updating the catalogsource to allow the operator to get deployed
* Clusters that don't support the setting (<4.12) will ignore it

Jira: [OSD-17160](https://issues.redhat.com//browse/OSD-17160)