### PR TITLE
Add the Tag User role permissionf for use with XPN PassThrough of OSD…

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR ${OPERATOR_PATH}
 # Build
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 ENV OPERATOR_PATH=/gcp-project-operator \
     OPERATOR_BIN=gcp-project-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/projectreference/projectreference_adapter.go
+++ b/controllers/projectreference/projectreference_adapter.go
@@ -85,9 +85,10 @@ var OSDReadOnlyConsoleAccessRoles = []string{
 var OSDSharedVPCRoles = []string{
 	"roles/iam.securityReviewer",
 	"roles/compute.loadBalancerAdmin",
+	"roles/resourcemanager.tagUser",
 }
 
-//ReferenceAdapter is used to do all the processing of the ProjectReference type inside the reconcile loop
+// ReferenceAdapter is used to do all the processing of the ProjectReference type inside the reconcile loop
 type ReferenceAdapter struct {
 	ProjectClaim     *gcpv1alpha1.ProjectClaim
 	ProjectReference *gcpv1alpha1.ProjectReference


### PR DESCRIPTION
…-ADMIN

### What type of PR is this? 
_(bug/feature/cleanup/docs/design/test/chore/refactor..)_
bug in the XPN flow

### What this PR does / why we need it:
* When using the osd-managed user with PassThrough for OSD GCP Shared VPC, on OCP 4.14 you need the "Tag User" role.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
https://issues.redhat.com/browse/SDE-3462

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [x] run the `make coverage` command to generate new calculated coverage