### PR TITLE
Add compute.networkAdmin to the osd-managed-admin SA when working wit…

### DIFF
--- a/controllers/projectreference/projectreference_adapter.go
+++ b/controllers/projectreference/projectreference_adapter.go
@@ -86,6 +86,7 @@ var OSDSharedVPCRoles = []string{
 	"roles/iam.securityReviewer",
 	"roles/compute.loadBalancerAdmin",
 	"roles/resourcemanager.tagUser",
+	"roles/compute.networkAdmin",
 }
 
 // ReferenceAdapter is used to do all the processing of the ProjectReference type inside the reconcile loop


### PR DESCRIPTION
…h OSD GCP Shared VPC's

### What type of PR is this? 
_(bug/feature/cleanup/docs/design/test/chore/refactor..)_
Shared VPC with passThrough (required) needs the osd-managed-admin to have compute.networkAdmin role in the Service Acount.

### What this PR does / why we need it:
Includes compute.networkAdmin on the osd-managed-admin in the Service Project.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [x] run the `make coverage` command to generate new calculated coverage