### PR TITLE
Add iam.roleAdmin to fix OSD GCP cluster with ver=4.15 / OSD-20510

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR ${OPERATOR_PATH}
 # Build
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
 ENV OPERATOR_PATH=/gcp-project-operator \
     OPERATOR_BIN=gcp-project-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/projectreference/projectreference_adapter.go
+++ b/controllers/projectreference/projectreference_adapter.go
@@ -49,16 +49,17 @@ var OSDRequiredAPIS = []string{
 	"networksecurity.googleapis.com", // https://bugzilla.redhat.com/show_bug.cgi?id=2021731
 }
 
-// OSDRequiredRoles is a list of Roles that a service account
-// required to setup Openshift cluster
+// OSDRequiredRoles is a list of Roles for service account osd-managed-admin
+// used by the cloud-credential-operator to setup Openshift cluster
 var OSDRequiredRoles = []string{
-	"roles/storage.admin",
-	"roles/iam.serviceAccountUser",
-	"roles/iam.serviceAccountKeyAdmin",
-	"roles/iam.serviceAccountAdmin",
-	"roles/iam.securityAdmin",
-	"roles/dns.admin",
 	"roles/compute.admin",
+	"roles/dns.admin",
+        "roles/iam.roleAdmin",
+	"roles/iam.securityAdmin",
+	"roles/iam.serviceAccountAdmin",
+	"roles/iam.serviceAccountKeyAdmin",
+	"roles/iam.serviceAccountUser",
+        "roles/storage.admin",
 }
 
 // OSDSREConsoleAccessRoles is a list of Roles that a service account


### PR DESCRIPTION
### What type of PR is this? 
feature

### What this PR does / why we need it:
Add iam.roleAdmin to fix OSD GCP cluster with ver=4.15

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
[OSD-20510](https://issues.redhat.com/browse/OSD-20510)

### Special notes for your reviewer:
Manually verified stage OSD GCP 4.15 rc.1

### Is it a breaking change or backward compatible?
No breaking changes

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage