### PR TITLE
Fix log statement to print function name

### DIFF
--- a/controllers/projectreference/projectreference_controller.go
+++ b/controllers/projectreference/projectreference_controller.go
@@ -123,7 +123,7 @@ func (r *ProjectReferenceReconciler) ReconcileHandler(adapter *ReferenceAdapter,
 	}
 	for _, operation := range operations {
 		if log.Log.V(3).Enabled() {
-			log.Log.V(3).Info("func", strings.Split(goruntime.FuncForPC(reflect.ValueOf(operation).Pointer()).Name(), ".")[2])
+			log.Log.V(3).Info("func", "name", strings.Split(goruntime.FuncForPC(reflect.ValueOf(operation).Pointer()).Name(), ".")[2])
 		}
 		result, err := operation(adapter)
 		if err != nil || result.RequeueRequest {


### PR DESCRIPTION
If the log level gets set to > 2 it will crash, because the logging function requires either 1 or an uneven number of arguments.

### What type of PR is this? 
_(bug/feature/cleanup/docs/design/test/chore/refactor..)_

### What this PR does / why we need it:

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage