### PR TITLE
Temporarily modify reconcile loop so that EnsureProjectConfigured will run

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=gcp.managed.openshift.io
+// +kubebuilder:object:generate=true
+// +groupName=gcp.managed.openshift.io
 package v1alpha1
 
 import (

--- a/api/v1alpha1/projectclaim_types.go
+++ b/api/v1alpha1/projectclaim_types.go
@@ -75,7 +75,7 @@ type ProjectClaim struct {
 	Status ProjectClaimStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 // ProjectClaimList contains a list of ProjectClaim
 type ProjectClaimList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/api/v1alpha1/projectreference_types.go
+++ b/api/v1alpha1/projectreference_types.go
@@ -29,7 +29,7 @@ type ProjectReferenceSpec struct {
 	CCS                bool           `json:"ccs,omitempty"`
 	CCSSecretRef       NamespacedName `json:"ccsSecretRef,omitempty"`
 	ServiceAccountName string         `json:"serviceAccountName,omitempty"`
-	SharedVPCAccess     bool          `json:"sharedVPCAccess,omitempty"`
+	SharedVPCAccess    bool           `json:"sharedVPCAccess,omitempty"`
 }
 
 // ProjectReferenceStatus defines the observed state of ProjectReference
@@ -59,8 +59,8 @@ const (
 	ProjectReferenceStatusVerification ProjectReferenceState = "Verification"
 )
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state",description="Status of the ProjectReference"
 // +kubebuilder:printcolumn:name="ClaimName",type="string",JSONPath=".spec.projectClaimCRLink.name",description="Name of corresponding project claim CR"

--- a/controllers/projectclaim/projectclaimadapter.go
+++ b/controllers/projectclaim/projectclaimadapter.go
@@ -63,9 +63,9 @@ func newMatchingProjectReference(projectClaim *gcpv1alpha1.ProjectClaim) *gcpv1a
 				Name:      projectClaim.GetName(),
 				Namespace: projectClaim.GetNamespace(),
 			},
-			LegalEntity:  *projectClaim.Spec.LegalEntity.DeepCopy(),
-			CCS:          projectClaim.Spec.CCS,
-			CCSSecretRef: *projectClaim.Spec.CCSSecretRef.DeepCopy(),
+			LegalEntity:     *projectClaim.Spec.LegalEntity.DeepCopy(),
+			CCS:             projectClaim.Spec.CCS,
+			CCSSecretRef:    *projectClaim.Spec.CCSSecretRef.DeepCopy(),
 			SharedVPCAccess: projectClaim.Spec.SharedVPCAccess,
 		},
 	}

--- a/controllers/projectreference/projectreference_adapter.go
+++ b/controllers/projectreference/projectreference_adapter.go
@@ -54,12 +54,12 @@ var OSDRequiredAPIS = []string{
 var OSDRequiredRoles = []string{
 	"roles/compute.admin",
 	"roles/dns.admin",
-        "roles/iam.roleAdmin",
+	"roles/iam.roleAdmin",
 	"roles/iam.securityAdmin",
 	"roles/iam.serviceAccountAdmin",
 	"roles/iam.serviceAccountKeyAdmin",
 	"roles/iam.serviceAccountUser",
-        "roles/storage.admin",
+	"roles/storage.admin",
 }
 
 // OSDSREConsoleAccessRoles is a list of Roles that a service account
@@ -133,7 +133,9 @@ func EnsureProjectClaimReady(r *ReferenceAdapter) (util.OperationResult, error) 
 	}
 
 	if r.ProjectReference.Status.State == gcpv1alpha1.ProjectReferenceStatusReady && r.ProjectClaim.Status.State == gcpv1alpha1.ClaimStatusReady {
-		return util.StopProcessing()
+		// TODO: Revert back to util.StopProcessing().
+		// This is so that EnsureProjectConfigured will run for OSD-20579
+		return util.ContinueProcessing()
 	}
 
 	res, err := r.ensureClaimAvailabilityZonesSet()
@@ -157,6 +159,11 @@ func EnsureProjectClaimReady(r *ReferenceAdapter) (util.OperationResult, error) 
 
 // VerifyProjectClaimPending waits until the ProjectClaim has been initialized, meaning is in state PendingProject
 func VerifyProjectClaimPending(r *ReferenceAdapter) (util.OperationResult, error) {
+	// TODO: Remove this block to continue processing when the ProjectClaim is Ready
+	// to ensure that EnsureProjectConfigured runs for OSD-20579
+	if r.ProjectClaim.Status.State == gcpv1alpha1.ClaimStatusReady {
+		return util.ContinueProcessing()
+	}
 	if r.ProjectClaim.Status.State != gcpv1alpha1.ClaimStatusPendingProject {
 		return util.RequeueAfter(5*time.Second, nil)
 	}

--- a/controllers/projectreference/projectreference_controller.go
+++ b/controllers/projectreference/projectreference_controller.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	gcpv1alpha1 "github.com/openshift/gcp-project-operator/api/v1alpha1"
-	condition "github.com/openshift/gcp-project-operator/pkg/condition"
+	"github.com/openshift/gcp-project-operator/pkg/condition"
 	operrors "github.com/openshift/gcp-project-operator/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 )

--- a/pkg/condition/conditions.go
+++ b/pkg/condition/conditions.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Conditions is a wrapper object for actual Condition functions to allow for easier mocking/testing.
+//
 //go:generate mockgen -destination=../util/mocks/$GOPACKAGE/conditions.go -package=$GOPACKAGE -source conditions.go
 type Conditions interface {
 	SetCondition(conditions *[]gcpv1alpha1.Condition, conditionType gcpv1alpha1.ConditionType, status corev1.ConditionStatus, reason string, message string)

--- a/pkg/gcpclient/client.go
+++ b/pkg/gcpclient/client.go
@@ -263,7 +263,7 @@ func (c *gcpClient) CreateServiceAccountKey(serviceAccountEmail string) (*iam.Se
 	return key, err
 }
 
-//DeleteServiceAccountKeys deletes all keys associated with the service account
+// DeleteServiceAccountKeys deletes all keys associated with the service account
 func (c *gcpClient) DeleteServiceAccountKeys(serviceAccountEmail string) error {
 	resource := fmt.Sprintf("projects/%s/serviceAccounts/%s", c.projectName, serviceAccountEmail)
 	response, err := c.iamClient.Projects.ServiceAccounts.Keys.List(resource).Do()


### PR DESCRIPTION
### What type of PR is this? 
feature

### What this PR does / why we need it:
We need to add an IAM role/rolebinding for existing osd-managed-admin serviceaccount that this operator creates. In the future, this serviceaccount will be managed by customers so that future permission changes in GCP can be actioned by the customer and not by us.

Also `go fmt`'d the codebase

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
[OSD-20579](https://issues.redhat.com//browse/OSD-20579)