### PR TITLE
Revert reconcile IAM serviceaccount rolebindings

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR ${OPERATOR_PATH}
 # Build
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706691034
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706795067
 ENV OPERATOR_PATH=/gcp-project-operator \
     OPERATOR_BIN=gcp-project-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706691034
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706795067
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/projectreference/projectreference_adapter.go
+++ b/controllers/projectreference/projectreference_adapter.go
@@ -133,9 +133,7 @@ func EnsureProjectClaimReady(r *ReferenceAdapter) (util.OperationResult, error) 
 	}
 
 	if r.ProjectReference.Status.State == gcpv1alpha1.ProjectReferenceStatusReady && r.ProjectClaim.Status.State == gcpv1alpha1.ClaimStatusReady {
-		// TODO: Revert back to util.StopProcessing().
-		// This is so that EnsureProjectConfigured will run for OSD-20579
-		return util.ContinueProcessing()
+		return util.StopProcessing()
 	}
 
 	res, err := r.ensureClaimAvailabilityZonesSet()
@@ -159,11 +157,6 @@ func EnsureProjectClaimReady(r *ReferenceAdapter) (util.OperationResult, error) 
 
 // VerifyProjectClaimPending waits until the ProjectClaim has been initialized, meaning is in state PendingProject
 func VerifyProjectClaimPending(r *ReferenceAdapter) (util.OperationResult, error) {
-	// TODO: Remove this block to continue processing when the ProjectClaim is Ready
-	// to ensure that EnsureProjectConfigured runs for OSD-20579
-	if r.ProjectClaim.Status.State == gcpv1alpha1.ClaimStatusReady {
-		return util.ContinueProcessing()
-	}
 	if r.ProjectClaim.Status.State != gcpv1alpha1.ClaimStatusPendingProject {
 		return util.RequeueAfter(5*time.Second, nil)
 	}


### PR DESCRIPTION
Soft revert of #216 

### What type of PR is this? 
cleanup

### What this PR does / why we need it:
A soft revert of 0c21ac1d878bc2432ee3752739462c6513ab76f3 where we retrofitted logic so that IAM serviceaccount rolebindings would be reconciled onto Ready ProjectReferences/ProjectClaims temporarily.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
[OSD-20579](https://issues.redhat.com//browse/OSD-20579)