### PR TITLE
feat(OSD-25439): Set up IAP permissions and api

### DIFF
--- a/controllers/projectreference/projectreference_adapter.go
+++ b/controllers/projectreference/projectreference_adapter.go
@@ -47,6 +47,7 @@ var OSDRequiredAPIS = []string{
 	"iamcredentials.googleapis.com",
 	"servicemanagement.googleapis.com",
 	"networksecurity.googleapis.com", // https://bugzilla.redhat.com/show_bug.cgi?id=2021731
+	"iap.googleapis.com ",            // https://issues.redhat.com/browse/OSD-25439 - required for PSC ssh access
 }
 
 // OSDRequiredRoles is a list of Roles for service account osd-managed-admin
@@ -73,6 +74,7 @@ var OSDSREConsoleAccessRoles = []string{
 	"roles/serviceusage.serviceUsageAdmin",
 	"roles/iam.roleAdmin",
 	"roles/cloudsupport.techSupportEditor",
+	"roles/iap.tunnelResourceAccessor", // https://issues.redhat.com/browse/OSD-25439 PSC SSH access
 }
 
 // OSDReadOnlyConsoleAccessRoles is a list of Roles that a service account


### PR DESCRIPTION
### What type of PR is this? 
feature

### What this PR does / why we need it:

This PR adds the api and permissions needed for IAP (identity aware proxy) SRE access, which will be used to ssh to nodes for GCP PSC clusters. 

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

Fixes #https://issues.redhat.com/browse/OSD-25439

### Special notes for your reviewer:
We don't need to reconcile all projects as PSC will only be for new clusters created after its release. 

For WIF, the enablement is done in the MCC wif template. 

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage