### PR TITLE
Fix typo in service api

### DIFF
--- a/controllers/projectreference/projectreference_adapter.go
+++ b/controllers/projectreference/projectreference_adapter.go
@@ -47,7 +47,7 @@ var OSDRequiredAPIS = []string{
 	"iamcredentials.googleapis.com",
 	"servicemanagement.googleapis.com",
 	"networksecurity.googleapis.com", // https://bugzilla.redhat.com/show_bug.cgi?id=2021731
-	"iap.googleapis.com ",            // https://issues.redhat.com/browse/OSD-25439 - required for PSC ssh access
+	"iap.googleapis.com",            // https://issues.redhat.com/browse/OSD-25439 - required for PSC ssh access
 }
 
 // OSDRequiredRoles is a list of Roles for service account osd-managed-admin


### PR DESCRIPTION
### What type of PR is this? 
bug

### What this PR does / why we need it:

Fixes typo in service api that was added in https://github.com/openshift/gcp-project-operator/pull/230

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage