### PR TITLE
Fix indentation in manifest.yaml

### DIFF
--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -45,4 +45,4 @@ spec:
         disabledRegions:
           description: Regions where project creation is disabled (YAML array format)
           type: string
-      type: object
+    type: object


### PR DESCRIPTION
There was a bug in the python script - this indentation was bad.

### What type of PR is this? 
bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage