### PR TITLE
Remove deprecated attributeRestrictions field from ClusterRole manifests

### DIFF
--- a/deploy/uhc_cluster_role.yaml
+++ b/deploy/uhc_cluster_role.yaml
@@ -21,7 +21,6 @@ rules:
   - create
 - apiGroups:
   - ""
-  attributeRestrictions: null
   resources:
   - configmaps
   verbs:

--- a/deploy_pko/ClusterRole-gcp-project-operator-client.yaml
+++ b/deploy_pko/ClusterRole-gcp-project-operator-client.yaml
@@ -24,7 +24,6 @@ rules:
   - create
 - apiGroups:
   - ''
-  attributeRestrictions: null
   resources:
   - configmaps
   verbs:


### PR DESCRIPTION
### What type of PR is this? 
bug fix

### What this PR does / why we need it:
removes the deprecated `attributeRestrictions` field from ClusterRole rbac manifests to fix Package Operator deployment failures.

the package was failing to progress past the rbac phase with error:

```
Message: Latest Revision is Unavailable: Phase "rbac", ClusterRole /gcp-project-operator-client: failed to create typed patch object (/gcp-project-operator-client; rbac.authorization.k8s.io/v1, Kind=ClusterRole): .rules[2].attributeRestrictions: field not declared in schema
```
the `attributeRestrictions` field was deprecated and removed from the k8s rbac api schema. this change removes it from both pko and legacy deployment manifests.

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
Related to [SREP-3558](https://redhat.atlassian.net/browse/SREP-3558)

### Special notes for your reviewer:
no functional changes to rbac permissions, only removing an deprecated field


### Is it a breaking change or backward compatible?
removes invalid field that was preventing deployment

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage