### PR TITLE
Fix service account namespace in ClusterRoleBindings

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR ${OPERATOR_PATH}
 # Build
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773939694
 ENV OPERATOR_PATH=/gcp-project-operator \
     OPERATOR_BIN=gcp-project-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773939694
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/uhc_cluster_role_binding.yaml
+++ b/deploy/uhc_cluster_role_binding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-project-operator-client
 subjects:
 - kind: ServiceAccount
-  namespace: gcp-project-operator-client
+  namespace: gcp-project-operator
   name: gcp-project-operator-client
 - kind: Group
   name: gcp-project-operator-client

--- a/deploy_pko/ClusterRoleBinding-gcp-project-operator-client.yaml
+++ b/deploy_pko/ClusterRoleBinding-gcp-project-operator-client.yaml
@@ -7,7 +7,7 @@ metadata:
     package-operator.run/collision-protection: IfNoController
 subjects:
 - kind: ServiceAccount
-  namespace: gcp-project-operator-client
+  namespace: gcp-project-operator
   name: gcp-project-operator-client
 - kind: Group
   name: gcp-project-operator-client


### PR DESCRIPTION
Complete the namespace fix that was started in commit 9c79f64. That commit fixed the ServiceAccount namespace from gcp-project-operator-client to gcp-project-operator, but the ClusterRoleBindings were never updated to match.

This latent bug went unnoticed because OLM deployments auto-generate RBAC from the CSV and don't use these standalone ClusterRoleBinding files. However, when migrating to PKO (Package Operator), these manifests are used directly, exposing the inconsistency.

This caused RBAC permission errors in staging after PKO migration: "User 'system:serviceaccount:gcp-project-operator:gcp-project-operator-client' cannot get resource 'projectclaims'"

Changes:
- Fix deploy/uhc_cluster_role_binding.yaml namespace reference
- Fix deploy_pko/ClusterRoleBinding-gcp-project-operator-client.yaml namespace reference

Both now correctly reference the gcp-project-operator namespace where the ServiceAccount actually exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### What type of PR is this? 
_(bug/feature/cleanup/docs/design/test/chore/refactor..)_
bug

### What this PR does / why we need it:
pko migration surfaced a bug 

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
part of olm -> pko migration: https://redhat.atlassian.net/browse/SREP-3558

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage