### PR TITLE
Restore list/watch and keep permissions not mentioned in the card.

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -12,19 +12,39 @@ rules:
       - create
       - delete
       - get
+      - list
+      - patch
       - update
+      - watch
   - apiGroups:
       - ""
     resources:
       - configmaps
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:
       - events
     verbs:
       - create
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - gcp-project-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
   - apiGroups:
       - gcp.managed.openshift.io
     resources:

--- a/deploy_pko/ClusterRole-gcp-project-operator.yaml
+++ b/deploy_pko/ClusterRole-gcp-project-operator.yaml
@@ -15,19 +15,39 @@ rules:
   - create
   - delete
   - get
+  - list
+  - patch
   - update
+  - watch
 - apiGroups:
   - ''
   resources:
   - configmaps
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ''
   resources:
   - events
   verbs:
   - create
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - gcp-project-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
 - apiGroups:
   - gcp.managed.openshift.io
   resources:


### PR DESCRIPTION
Prior RBAC change removed list/watch on secrets and configmaps which controller-runtime needs for its informer cache. This caused forbidden errors on staging.

https://redhat.atlassian.net/browser/ROSAENG-61324

### What type of PR is this?
bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
https://redhat.atlassian.net/browser/ROSAENG-61324

_Fixes #_

### Special notes for your reviewer:

### Is it a breaking change or backward compatible?

### Pre-checks:
- [ ] manually tested latest changes against crc/k8s
- [ ] run the `make coverage` command to generate new calculated coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved project operator capabilities for managing secrets and config maps.
  * Added support for creating and retrieving service monitors.
  * Added support for updating the operator deployment’s finalizer status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->